### PR TITLE
ORFS-80: remove a compute node

### DIFF
--- a/lib/graphs/discovery-sku-graph.js
+++ b/lib/graphs/discovery-sku-graph.js
@@ -64,6 +64,13 @@ module.exports = {
                             }
                         },
                         {
+                            "type": "common",
+                            "pollInterval": 60000,
+                            "config": {
+                                "command": "ping"
+                            }
+                        },
+                        {
                             "type": "ipmi",
                             "pollInterval": 15000,
                             "config": {

--- a/lib/graphs/poller-service-graph.js
+++ b/lib/graphs/poller-service-graph.js
@@ -25,6 +25,11 @@ module.exports = {
                 timeout: -1
             }
         },
+        'common-network-command': {
+            schedulerOverrides: {
+                timeout: -1
+            }
+        },
         'ipmi-sdr-alert': {
             schedulerOverrides: {
                 timeout: -1
@@ -36,6 +41,11 @@ module.exports = {
             }
         },
         'snmp-alert': {
+            schedulerOverrides: {
+                timeout: -1
+            }
+        },
+        'ping-alert': {
             schedulerOverrides: {
                 timeout: -1
             }
@@ -88,6 +98,16 @@ module.exports = {
             }
         },
         {
+            label: 'common-network-command',
+            taskDefinition: {
+                friendlyName: 'Common Network Command requester',
+                injectableName: 'Task.Inline.Common.Network.Command',
+                implementsTask: 'Task.Base.Common.Network.Command',
+                options: {},
+                properties: {}
+            }
+        },
+        {
             label: 'ipmi-sdr-alert',
             taskDefinition: {
                 friendlyName: 'IPMI Sdr alerter',
@@ -113,6 +133,16 @@ module.exports = {
                 friendlyName: 'SNMP alerter',
                 injectableName: 'Task.Inline.Poller.Alert.Snmp',
                 implementsTask: 'Task.Base.Poller.Alert.Snmp',
+                options: {},
+                properties: {}
+            }
+        },
+        {
+            label: 'ping-alert',
+            taskDefinition: {
+                friendlyName: 'Ping alerter',
+                injectableName: 'Task.Inline.Poller.Alert.Ping',
+                implementsTask: 'Task.Base.Poller.Alert.Ping',
                 options: {},
                 properties: {}
             }


### PR DESCRIPTION
1. add command network command poller in discovery graph, using tool
   like 'ping'
2. add ping alerts to poller service graph to detect connections

Other related repo change links:
https://github.com/RackHD/on-tasks/pull/16
https://github.com/RackHD/on-core/pull/7
https://github.com/RackHD/on-http/pull/13
https://github.com/RackHD/onserve/pull/24

JIRA link:
https://hwjiraprd01.corp.emc.com/browse/ORFS-80
