### PR TITLE
Scheduler: call taskProtocol.cancel with timeout error/message on tim…

### DIFF
--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -16,6 +16,7 @@ di.annotate(factory,
         'Logger',
         'Assert',
         'Util',
+        'Errors',
         'uuid',
         'Promise',
         '_'
@@ -28,7 +29,7 @@ di.annotate(factory,
  * @returns {Scheduler}
  */
 function factory(schedulerProtocol, eventsProtocol, taskProtocol, Logger,
-        assert, util, uuid, Promise, _) {
+        assert, util, Errors, uuid, Promise, _) {
     var logger = Logger.initialize(factory);
 
     /**
@@ -355,7 +356,8 @@ function factory(schedulerProtocol, eventsProtocol, taskProtocol, Logger,
                 task: workItem.id
             };
             if (err === 'timeout') {
-                taskProtocol.cancel(workItem.id);
+                taskProtocol.cancel(workItem.id, Errors.TaskTimeoutError.name,
+                        'Task timed out after %sms'.format(workItem.timeout));
             }
         } else {
             this.stats.tasksSuccess += 1;


### PR DESCRIPTION
…eout

Task timeout errors have not been getting sent to running tasks when the scheduler times them out, so on cancellation they end up getting marked as succeeded instead of timed out.

Relies on https://github.com/RackHD/on-tasks/pull/53 and https://github.com/RackHD/on-core/pull/20

https://hwjiraprd01.corp.emc.com/browse/ODR-273
https://hwjiraprd01.corp.emc.com/browse/MON-633
