### PR TITLE
Fix ODR273: Add 1 hour timeout for ESXi/RHEL/CentOS bootstrap

### DIFF
--- a/lib/graphs/install-centos-graph.js
+++ b/lib/graphs/install-centos-graph.js
@@ -6,7 +6,10 @@ module.exports = {
     options: {
         'install-os': {
             version: null,
-            repo: '{{api.server}}/centos/{{options.version}}/os/x86_64'
+            repo: '{{api.server}}/centos/{{options.version}}/os/x86_64',
+            schedulerOverrides: {
+                timeout: 3600000 //1 hour
+            }
         }
     },
     tasks: [

--- a/lib/graphs/install-esx-graph.js
+++ b/lib/graphs/install-esx-graph.js
@@ -6,7 +6,10 @@ module.exports = {
     options: {
         'install-os': {
             version: '5.5',
-            repo: '{{api.server}}/esxi/{{options.version}}'
+            repo: '{{api.server}}/esxi/{{options.version}}',
+            schedulerOverrides: {
+                timeout: 3600000 //1 hour
+            }
         }
     },
     tasks: [

--- a/lib/graphs/install-esx60-graph.js
+++ b/lib/graphs/install-esx60-graph.js
@@ -3,7 +3,10 @@ module.exports = {
     injectableName: 'Graph.InstallEsx60',
     options: {
         "install-os": {
-            rootPassword: null
+            rootPassword: null,
+            schedulerOverrides: {
+                timeout: 3600000 //1 hour
+            }
         }
     },
     tasks: [

--- a/lib/graphs/install-rhel-graph.js
+++ b/lib/graphs/install-rhel-graph.js
@@ -6,7 +6,10 @@ module.exports = {
     options: {
         'install-os': {
             version: null,
-            repo: '{{api.server}}/rhel/{{options.version}}/os/x86_64'
+            repo: '{{api.server}}/rhel/{{options.version}}/os/x86_64',
+            schedulerOverrides: {
+                timeout: 3600000 //1 hour
+            }
         }
     },
     tasks: [


### PR DESCRIPTION
Fix ODR-237, add 1 hour timeout for OS bootstrap task to avoid workflow hang for a long time.

https://hwjiraprd01.corp.emc.com/browse/ODR-273
