### PR TITLE
Fix ODR273: Add 1 hour timeout for ESXi/RHEL/CentOS bootstrap

### DIFF
--- a/lib/graphs/install-centos-graph.js
+++ b/lib/graphs/install-centos-graph.js
@@ -6,7 +6,10 @@ module.exports = {
     options: {
         'install-os': {
             version: null,
-            repo: '{{api.server}}/centos/{{options.version}}/os/x86_64'
+            repo: '{{api.server}}/centos/{{options.version}}/os/x86_64',
+            schedulerOverrides: {
+                timeout: 3600000 //1 hour
+            }
         }
     },
     tasks: [

--- a/lib/graphs/install-esx-graph.js
+++ b/lib/graphs/install-esx-graph.js
@@ -6,7 +6,10 @@ module.exports = {
     options: {
         'install-os': {
             version: null,
-            repo: '{{api.server}}/esxi/{{options.version}}'
+            repo: '{{api.server}}/esxi/{{options.version}}',
+            schedulerOverrides: {
+                timeout: 3600000 //1 hour
+            }
         }
     },
     tasks: [

--- a/lib/graphs/install-rhel-graph.js
+++ b/lib/graphs/install-rhel-graph.js
@@ -6,7 +6,10 @@ module.exports = {
     options: {
         'install-os': {
             version: null,
-            repo: '{{api.server}}/rhel/{{options.version}}/os/x86_64'
+            repo: '{{api.server}}/rhel/{{options.version}}/os/x86_64',
+            schedulerOverrides: {
+                timeout: 3600000 //1 hour
+            }
         }
     },
     tasks: [


### PR DESCRIPTION
Fix ODR-273, add 1 hour timeout for OS bootstrap task to avoid workflow hang for a long time.
https://hwjiraprd01.corp.emc.com/browse/ODR-273

This PR is opened against 1.0.0 branch. Since ODR-273 is P1 issue, we don't have to merge to 1.0.0 branch. But I heard news this may need to be included 1.0.4 release. So if we need this fix for 1.0.0 branch, you can review and merge it. If not, you can just ignore this PR, I will close it later.

@RackHD/corecommitters  @benbp  @iceiilin  @WangWinson @pengz1 