### PR TITLE
Add workflow to clear drive partition

### DIFF
--- a/lib/graphs/clear-drive-partition-graph.js
+++ b/lib/graphs/clear-drive-partition-graph.js
@@ -1,0 +1,34 @@
+// Copyright 2015, EMC, Inc.
+
+module.exports = {
+    friendlyName: 'Clear Drives Partition',
+    injectableName: 'Graph.ClearDrivePartition',
+    tasks: [
+        {
+            label: 'set-boot-pxe',
+            taskName: 'Task.Obm.Node.PxeBoot',
+            ignoreFailure: true
+        },
+        {
+            label: 'reboot',
+            taskName: 'Task.Obm.Node.Reboot',
+            waitOn: {
+                'set-boot-pxe': 'finished'
+            }
+        },
+        {
+            label: 'bootstrap-ubuntu',
+            taskName: 'Task.Linux.Bootstrap.Ubuntu',
+            waitOn: {
+                'reboot': 'succeeded'
+            }
+        },
+        {
+            label: 'clear-drive-partition',
+            taskName: 'Task.Drive.Clear.Partition',
+            waitOn: {
+                'bootstrap-ubuntu': 'succeeded'
+            }
+        }
+    ]
+};

--- a/spec/lib/graphs/clear-drive-partition-spec.js
+++ b/spec/lib/graphs/clear-drive-partition-spec.js
@@ -1,0 +1,17 @@
+// Copyright 2015, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-graph-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/graphs/clear-drive-partition-graph.js');
+    });
+
+    describe('graph', function () {
+        base.examples();
+    });
+
+});


### PR DESCRIPTION
This PR is to implement a workflow to clear all partition for target drives.

It is a sub-feature of ORFS-97 [Extend base OS and workflow to configure RAID array prior to bootstrap](https://hardware.corp.emc.com/display/CI/Extend+base+OS+and+workflow+to+configure+RAID+array+prior+to+bootstrap).

This workflow will be eventually embedded in OS bootstrap workflow, as we found some error when install ESXi and Redhat alternately, if the drive partition is corrupted, the ESXi installation will fail, so we have to manually reset the drive config. So if this workflow is inserted, we can avoid such manual work.

The drive partition operation will depend on a tool named "parted", @iceiilin opened another PR (https://github.com/RackHD/on-imagebuilder/pull/7) to include this tool in our micorkernel.

@RackHD/corecommitters @iceiilin @WangWinson @pengz1 @sunnyqianzhang @zyoung51 

The dependent PRs: 
 - https://github.com/RackHD/on-imagebuilder/pull/7
 - https://github.com/RackHD/on-tasks/pull/71

