### PR TITLE
rationalizing logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,9 +30,12 @@ taskGraphRunner.start()
         logger.info('Task Graph Runner Started.');
     })
     .catch(function(error) {
+        //NOTE(heckj): I'm unclear why this is on the console directly and not
+        // using a logger. Would expect this to be logger.critical(), but
+        // leaving as is because I don't know the implications.
         console.error(error.message || error.details);
         console.error(error.stack || error.rawStack);
-//        logger.error('Task Graph Runner Startup Error.', { error: error });
+//      logger.critical('Task Graph Runner Startup Error.', { error: error });
 
         process.nextTick(function() {
             process.exit(1);
@@ -42,7 +45,7 @@ taskGraphRunner.start()
 process.on('SIGINT', function() {
     taskGraphRunner.stop()
         .catch(function(error) {
-            logger.error('Task Graph Runner Shutdown Error.', { error: error });
+            logger.critical('Task Graph Runner Shutdown Error.', { error: error });
         })
         .finally(function() {
             process.nextTick(function() {

--- a/lib/context.js
+++ b/lib/context.js
@@ -38,7 +38,7 @@ function factory(Logger, assert, _) {
         }
 
         var optionDefaults = {
-            logLevel: 'info'
+            logLevel: 'debug'
         };
         this.options = _.defaults(overrides || {}, optionDefaults);
 

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -47,7 +47,7 @@ function factory(schedulerProtocol, eventsProtocol, taskProtocol, Logger,
         var optionDefaults = {
             name: 'Default Scheduler Name',
             concurrentTasks: 100,
-            logLevel: 'info',
+            logLevel: 'debug',
             defaultPriority: 50,
             defaultTimeout: (24 * 60 * 60 * 1000),
             maxCompletedTasks: 200

--- a/lib/task-graph.js
+++ b/lib/task-graph.js
@@ -460,7 +460,7 @@ function factory(Task, scheduler, registry, eventsProtocol, schedulerProtocol,
         });
         if (failedTask) {
             self._status = TaskStates.Failed;
-            logger.info("Task failure, stopping TaskGraph and remaining tasks/jobs.",
+            logger.warning("Task failure, stopping TaskGraph and remaining tasks/jobs.",
                     _.defaults({ taskError: failedTask.error }, this.logContext));
             self.stop(TaskStates.Failed);
             return true;


### PR DESCRIPTION
updating mapping to more constricted set of logs per
https://github.com/RackHD/RackHD/issues/34

**NOTE**: Requires https://github.com/RackHD/on-core/pull/48 to be
committed prior as it adds the synonym 'critical' to the existing 'crit'
level.