### PR TITLE
Set mgmt server discovery task in serial manner

### DIFF
--- a/lib/graphs/discovery-mgmt-graph.js
+++ b/lib/graphs/discovery-mgmt-graph.js
@@ -14,11 +14,17 @@ module.exports = {
         {
             label: 'catalog-mgmt-lldp',
             taskName: 'Task.Catalog.Local.LLDP',
+            waitOn: {
+                'catalog-mgmt-bmc': 'finished'
+            },
             ignoreFailure: true
         },
         {
             label: 'catalog-mgmt-dmi',
             taskName: 'Task.Catalog.Local.DMI',
+            waitOn: {
+                'catalog-mgmt-lldp': 'finished'
+            },
             ignoreFailure: true
         }
     ]


### PR DESCRIPTION
Set mgmt server discovery tasks work in serial manner to avoid task scheduling competition. Otherwise a mongoError is likely to report with a long dump log:
2016-01-12T09:49:55.806Z [on-taskgraph] [TaskGraph.TaskGraph] [Server] Error persisting Task Graph state
 -> /lib/task-graph.js:483     
    """
      Details:  { name: 'MongoError',
        message: 'Object #<Object> has no method \'value\'',
        driver: true,
        ok: 1,
        n: 0,
        code: 14,
        errmsg: 'Object #<Object> has no method \'value\'',
        writeErrors: 
         [ { index: 0,
             code: 14,
             errmsg: 'Object #<Object> has no method \'value\'' } ] }
      
    """