### PR TITLE
Set mgmt server discovery task to run in a serial manner

### DIFF
--- a/lib/graphs/discovery-mgmt-graph.js
+++ b/lib/graphs/discovery-mgmt-graph.js
@@ -14,11 +14,17 @@ module.exports = {
         {
             label: 'catalog-mgmt-lldp',
             taskName: 'Task.Catalog.Local.LLDP',
+            waitOn: {
+                'catalog-mgmt-bmc': 'finished'
+            },
             ignoreFailure: true
         },
         {
             label: 'catalog-mgmt-dmi',
             taskName: 'Task.Catalog.Local.DMI',
+            waitOn: {
+                'catalog-mgmt-lldp': 'finished'
+            },
             ignoreFailure: true
         }
     ]


### PR DESCRIPTION
The same PR to 1.1.0 branch as https://github.com/RackHD/on-taskgraph/pull/43 (has merged) to master branch. Set mgmt server discovery tasks work in serial manner to avoid task scheduling competition.