### PR TITLE
Bugfix/use ipmitool 1.8.13 1 1.1

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,13 +7,6 @@ Standards-Version: 3.9.4
 
 Package: on-taskgraph
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends},
- nodejs,
- nodejs-legacy,
- npm,
- mongodb,
- snmp,
- ipmitool
+Depends: ${shlibs:Depends}, ${misc:Depends}, nodejs, nodejs-legacy, npm, mongodb, snmp, ipmitool
 Suggests: python-pywbem, ansible, apt-mirror, amtterm
-Description: on-taskgraph
- Imaging Workflow taskgraph engine
+Description: RackHD Imaging workflow taskgraph engine

--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Standards-Version: 3.9.4
 
 Package: on-taskgraph
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, nodejs, nodejs-legacy, npm, mongodb, snmp, ipmitool
+Depends: ${shlibs:Depends}, ${misc:Depends}, nodejs, nodejs-legacy, npm, mongodb, snmp, ipmitool (=1.8.13-1)
 Suggests: python-pywbem, ansible, apt-mirror, amtterm
 Description: RackHD Imaging workflow taskgraph engine

--- a/lib/graphs/discovery-mgmt-graph.js
+++ b/lib/graphs/discovery-mgmt-graph.js
@@ -14,11 +14,17 @@ module.exports = {
         {
             label: 'catalog-mgmt-lldp',
             taskName: 'Task.Catalog.Local.LLDP',
+            waitOn: {
+                'catalog-mgmt-bmc': 'finished'
+            },
             ignoreFailure: true
         },
         {
             label: 'catalog-mgmt-dmi',
             taskName: 'Task.Catalog.Local.DMI',
+            waitOn: {
+                'catalog-mgmt-lldp': 'finished'
+            },
             ignoreFailure: true
         }
     ]

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "di": "git+https://github.com/RackHD/di.js.git",
+    "di": "git+https://github.com/RackHD/di.js.git#release/1.1.0-branch",
     "dot-object": "^0.6.0",
     "lodash": "^2.4.1",
     "lru-cache": "^2.5.0",
     "node-uuid": "^1.4.2",
-    "on-core": "git+https://github.com/RackHD/on-core.git",
-    "on-tasks": "git+https://github.com/RackHD/on-tasks.git",
+    "on-core": "git+https://github.com/RackHD/on-core.git#release/1.1.0-branch",
+    "on-tasks": "git+https://github.com/RackHD/on-tasks.git#release/1.1.0-branch",
     "rx": "^2.3.22"
   },
   "devDependencies": {


### PR DESCRIPTION
Need to specify the ipmitool version to avoid a current bug in version 1.8.13-1ubuntu0.6 of ipmitool that breaks the fru command. This change should be merged with the similar PRs in onrack-infra onrack-base, and on-taskgraph master branch.