### PR TITLE
Specify version 1.8.13-1 for ipmitool package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Standards-Version: 3.9.4
 
 Package: on-taskgraph
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, nodejs, nodejs-legacy, npm, mongodb, snmp, ipmitool
+Depends: ${shlibs:Depends}, ${misc:Depends}, nodejs, nodejs-legacy, npm, mongodb, snmp, ipmitool (=1.8.13-1)
 Suggests: python-pywbem, ansible, apt-mirror, amtterm
 Description: RackHD Imaging workflow taskgraph engine


### PR DESCRIPTION
Need to specify the ipmitool version to avoid a current bug in version 1.8.13-1ubuntu0.6 of ipmitool that breaks the fru command. This change should be merged with the similar PRs in onrack-infra, onrack-base, and on-taskgraph master branch.