### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2016, EMC, Inc.
+
+FROM rackhd/on-core
+
+RUN mkdir -p /RackHD/on-taskgraph
+WORKDIR /RackHD/on-taskgraph
+
+COPY ./package.json /tmp/
+RUN cd /tmp \
+  && ln -s /RackHD/on-core /tmp/node_modules/on-core \
+  && ln -s /RackHD/on-core/node_modules/di /tmp/node_modules/di \
+  && npm install --ignore-scripts --production
+
+COPY . /RackHD/on-taskgraph/
+RUN cp -a /tmp/node_modules /RackHD/on-taskgraph/
+
+RUN apt-get update && apt-get install -y isc-dhcp-server
+
+ENV dhcpGateway $dhcpGateway
+
+EXPOSE 67
+EXPOSE 67/udp
+
+ENTRYPOINT [ "/RackHD/on-taskgraph/docker_entry.sh" ]

--- a/docker_entry.sh
+++ b/docker_entry.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Copyright 2016, EMC, Inc.
+dhcpd & node index.js


### PR DESCRIPTION
Dockerfile for building on-taskgraph image.

Needed to add `docker_entry.sh` in order to run `dhcpd` and `node`.