### PR TITLE
Specify version 1.8.13-1 for ipmitool package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Standards-Version: 3.9.4
 
 Package: on-taskgraph
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, nodejs, nodejs-legacy, npm, mongodb, snmp, ipmitool
+Depends: ${shlibs:Depends}, ${misc:Depends}, nodejs, nodejs-legacy, npm, mongodb, snmp, ipmitool (=1.8.13-1)
 Suggests: python-pywbem, ansible, apt-mirror, amtterm
 Description: RackHD Imaging workflow taskgraph engine


### PR DESCRIPTION
Trying this again, hopefully with all of the dependencies this time.  For ODR-352.

This depends on https://eos2git.cec.lab.emc.com/OnRack/onrack-base/pull/2

DO NOT MERGE until both of these PRs are ready.