### PR TITLE
ODR-547 Updated discovery-refresh-graphs.js to use sku discovery

### DIFF
--- a/lib/graphs/discovery-refresh-graph.js
+++ b/lib/graphs/discovery-refresh-graph.js
@@ -5,15 +5,27 @@
 module.exports = {
     friendlyName: 'Refresh node',
     injectableName: 'Graph.Refresh.Discovery',
-    "options": {
-        "discovery-refresh-graph": {
-            "graphOptions": {
-                "target": null
-            }
+    options: {
+        'reboot-at-start': {
+            nodeId: null
         },
-        "reboot-at-start": {
-            "nodeId": null
-        }
+        'discovery-refresh-graph': {
+            graphOptions: {
+                target: null
+            },
+        },
+        'generate-sku': {
+            nodeId: null
+        },
+        'generate-enclosure': {
+            nodeId: null
+        },
+        'create-default-pollers': {
+            nodeId: null
+        },
+        'run-sku-graph': {
+            nodeId: null
+        },
     },
     tasks: [
         {
@@ -23,7 +35,7 @@ module.exports = {
         {
             label: 'discovery-refresh-graph',
             taskDefinition: {
-                friendlyName: 'Run Discovery Graph',
+                friendlyName: 'Run Discovery Refresh Graph',
                 injectableName: 'Task.Graph.Run.Discovery',
                 implementsTask: 'Task.Base.Graph.Run',
                 options: {
@@ -34,7 +46,88 @@ module.exports = {
             },
             waitOn: {
                 'reboot-at-start': 'succeeded'
+            },
+        },
+        {
+            label: 'generate-sku',
+            waitOn: {
+                'discovery-refresh-graph': 'succeeded'
+            },
+            taskName: 'Task.Catalog.GenerateSku',
+        },
+        {
+            label: 'generate-enclosure',
+            waitOn: {
+                'discovery-refresh-graph': 'succeeded'
+            },
+            taskName: 'Task.Catalog.GenerateEnclosure',
+            ignoreFailure: true
+        },
+        {
+            label: 'create-default-pollers',
+            taskDefinition: {
+                friendlyName: 'Create Default Pollers',
+                injectableName: 'Task.Inline.Pollers.CreateDefault',
+                implementsTask: 'Task.Base.Pollers.CreateDefault',
+                properties: {},
+                options: {
+                    nodeId: null,
+                    pollers: [
+                        {
+                            "type": "ipmi",
+                            "pollInterval": 60000,
+                            "config": {
+                                "command": "sdr"
+                            }
+                        },
+                        {
+                            "type": "ipmi",
+                            "pollInterval": 60000,
+                            "config": {
+                                "command": "selInformation"
+                            }
+                        },
+                        {
+                            "type": "ipmi",
+                            "pollInterval": 60000,
+                            "config": {
+                                "command": "sel"
+                            }
+                        },
+                        {
+                            "type": "ipmi",
+                            "pollInterval": 15000,
+                            "config": {
+                                "command": "chassis"
+                            }
+                        },
+                        {
+                            "type": "ipmi",
+                            "pollInterval": 30000,
+                            "config": {
+                                "command": "driveHealth"
+                            }
+                        }
+                    ]
+                }
+            },
+            waitOn: {
+                'discovery-refresh-graph': 'succeeded'
             }
+        },
+        {
+            label: 'run-sku-graph',
+            taskDefinition: {
+                friendlyName: 'Run SKU-specific graph',
+                injectableName: 'Task.Graph.Run.SkuSpecific',
+                implementsTask: 'Task.Base.Graph.RunSku',
+                options: {},
+                properties: {}
+            },
+            waitOn: {
+                'generate-sku': 'succeeded'
+            }
+
         }
     ]
 };


### PR DESCRIPTION
ODR-547 Updated discovery-refresh-graphs.js to use sku discovery tasks instead of just discovery.

(cherry picked from commit 90928e38ff98a2a4d2880233f91dbf4adabfef3d)