### PR TITLE
ODR-547 Established new refresh graphs

### DIFF
--- a/lib/graphs/discovery-refresh-delayed-graph.js
+++ b/lib/graphs/discovery-refresh-delayed-graph.js
@@ -3,12 +3,9 @@
 'use strict';
 
 module.exports = {
-    friendlyName: 'Refresh node',
-    injectableName: 'Graph.Refresh.Discovery',
+    friendlyName: 'Refresh node delayed',
+    injectableName: 'Graph.Refresh.Delayed.Discovery',
     options: {
-        'reset-at-start': {
-            nodeId: null
-        },
         'discovery-refresh-graph': {
             graphOptions: {
                 target: null
@@ -31,10 +28,6 @@ module.exports = {
     },
     tasks: [
         {
-            label: 'reset-at-start',
-            taskName: 'Task.Obm.Node.Reset'
-        },
-        {
             label: 'discovery-refresh-graph',
             taskDefinition: {
                 friendlyName: 'Run Discovery Refresh Graph',
@@ -45,9 +38,6 @@ module.exports = {
                     graphOptions: {}
                 },
                 properties: {}
-            },
-            waitOn: {
-                'reset-at-start': 'succeeded'
             },
         },
         {
@@ -116,20 +106,6 @@ module.exports = {
             waitOn: {
                 'discovery-refresh-graph': 'succeeded'
             }
-        },
-        {
-            label: 'run-sku-graph',
-            taskDefinition: {
-                friendlyName: 'Run SKU-specific graph',
-                injectableName: 'Task.Graph.Run.SkuSpecific',
-                implementsTask: 'Task.Base.Graph.RunSku',
-                options: {},
-                properties: {}
-            },
-            waitOn: {
-                'generate-sku': 'succeeded'
-            }
-
         }
     ]
 };

--- a/lib/graphs/discovery-refresh-immediate-graph.js
+++ b/lib/graphs/discovery-refresh-immediate-graph.js
@@ -1,0 +1,121 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Refresh node immediate',
+    injectableName: 'Graph.Refresh.Immediate.Discovery',
+    options: {
+         'reset-at-start': {
+             nodeId: null
+         },
+        'discovery-refresh-graph': {
+            graphOptions: {
+                target: null
+            },
+            nodeId: null
+        },
+        'generate-sku': {
+            nodeId: null
+        },
+        'generate-enclosure': {
+            nodeId: null
+        },
+        'create-default-pollers': {
+            nodeId: null
+        },
+        'run-sku-graph': {
+            nodeId: null
+        },
+        nodeId: null
+    },
+    tasks: [
+        {
+            label: 'reset-at-start',
+            taskName: 'Task.Obm.Node.Reset'
+        },
+        {
+            label: 'discovery-refresh-graph',
+            taskDefinition: {
+                friendlyName: 'Run Discovery Refresh Graph',
+                injectableName: 'Task.Graph.Run.Discovery',
+                implementsTask: 'Task.Base.Graph.Run',
+                options: {
+                    graphName: 'Graph.Discovery',
+                    graphOptions: {}
+                },
+                properties: {}
+            },
+            waitOn: {
+                'reset-at-start': 'succeeded'
+            },
+        },
+        {
+            label: 'generate-sku',
+            waitOn: {
+                'discovery-refresh-graph': 'succeeded'
+            },
+            taskName: 'Task.Catalog.GenerateSku',
+        },
+        {
+            label: 'generate-enclosure',
+            waitOn: {
+                'discovery-refresh-graph': 'succeeded'
+            },
+            taskName: 'Task.Catalog.GenerateEnclosure',
+            ignoreFailure: true
+        },
+        {
+            label: 'create-default-pollers',
+            taskDefinition: {
+                friendlyName: 'Create Default Pollers',
+                injectableName: 'Task.Inline.Pollers.CreateDefault',
+                implementsTask: 'Task.Base.Pollers.CreateDefault',
+                properties: {},
+                options: {
+                    nodeId: null,
+                    pollers: [
+                        {
+                            "type": "ipmi",
+                            "pollInterval": 60000,
+                            "config": {
+                                "command": "sdr"
+                            }
+                        },
+                        {
+                            "type": "ipmi",
+                            "pollInterval": 60000,
+                            "config": {
+                                "command": "selInformation"
+                            }
+                        },
+                        {
+                            "type": "ipmi",
+                            "pollInterval": 60000,
+                            "config": {
+                                "command": "sel"
+                            }
+                        },
+                        {
+                            "type": "ipmi",
+                            "pollInterval": 15000,
+                            "config": {
+                                "command": "chassis"
+                            }
+                        },
+                        {
+                            "type": "ipmi",
+                            "pollInterval": 30000,
+                            "config": {
+                                "command": "driveHealth"
+                            }
+                        }
+                    ]
+                }
+            },
+            waitOn: {
+                'discovery-refresh-graph': 'succeeded'
+            }
+        }
+    ]
+};

--- a/lib/graphs/discovery-refresh-immediate-graph.js
+++ b/lib/graphs/discovery-refresh-immediate-graph.js
@@ -6,9 +6,9 @@ module.exports = {
     friendlyName: 'Refresh node immediate',
     injectableName: 'Graph.Refresh.Immediate.Discovery',
     options: {
-         'reset-at-start': {
-             nodeId: null
-         },
+        'reset-at-start': {
+            nodeId: null
+        },
         'discovery-refresh-graph': {
             graphOptions: {
                 target: null


### PR DESCRIPTION
1) discovery-refresh-delayed-graph.js : starts refresh
   without first doing a reset.
2) discovery-refresh-immediate-graph.js : starts refresh
   by first doing a reset.

Removed existing RunSKU portion of these workflows.