### PR TITLE
Publish error message with task finished events

### DIFF
--- a/lib/task-runner.js
+++ b/lib/task-runner.js
@@ -354,6 +354,7 @@ function taskRunnerFactory(
                         taskId: task.instanceId,
                         graphId: task.context.graphId,
                         state: task.state,
+                        error: task.error,
                         context: task.context
                     })
                 ]);
@@ -375,11 +376,18 @@ function taskRunnerFactory(
      * @memberOf TaskRunner
      */
     TaskRunner.prototype.publishTaskFinished = function(task) {
+        var errorMsg;
+        if (task.error && task.error.stack) {
+            errorMsg = task.error.stack;
+        } else if (task.error) {
+            errorMsg = task.error.toString();
+        }
         return taskMessenger.publishTaskFinished(
             this.domain,
             task.instanceId,
             task.context.graphId,
             task.state,
+            errorMsg,
             task.context,
             task.definition.terminalOnStates
         )


### PR DESCRIPTION
Publish error messages for finished tasks so that they get persisted into the graph document. This makes it easier to debug failed workflows. Minor feature regression.

Requires https://github.com/RackHD/on-core/pull/92 and https://github.com/RackHD/on-tasks/pull/135

@RackHD/corecommitters @VulpesArtificem 