### PR TITLE
Add taskgraph for getting configure catalog with dell racadm tool

### DIFF
--- a/lib/graphs/dell-racadm-get-config-catalog-graph.js
+++ b/lib/graphs/dell-racadm-get-config-catalog-graph.js
@@ -1,0 +1,15 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Dell Racadm Get Config Catalog Graph',
+    injectableName: 'Graph.Dell.Racadm.GetConfigCatalog',
+    option: {},
+    tasks: [
+        {
+            label: 'dell-racadm-get-config-catalog',
+            taskName: 'Task.Dell.Racadm.GetConfigCatalog'
+        }
+    ]
+};

--- a/spec/lib/graphs/dell-racadm-get-config-catalog-graph-spec.js
+++ b/spec/lib/graphs/dell-racadm-get-config-catalog-graph-spec.js
@@ -1,0 +1,18 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-graph-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require(
+            '/lib/graphs/dell-racadm-get-config-catalog-graph.js');
+    });
+
+    describe('graph', function () {
+        base.examples();
+    });
+
+});


### PR DESCRIPTION
This PR is depend on another PR in the on-tasks repo:
https://github.com/RackHD/on-tasks/pull/137

The root cause of  continuous-integration/travis-ci/pr  is identified in the following link:
https://travis-ci.org/RackHD/on-taskgraph/jobs/113595827
It has nothing to do with this PR. @jlongever, could you please help take a look? 
  1) Graph Library "before all" hook:
     Error: Cannot find module 'redfish-node'
      at require (internal/module.js:16:19)
      at Object.<anonymous> (node_modules/on-tasks/lib/jobs/redfish-discovery.js:6:15)

The jenkins failure is due to the dependency on the tasks as described in above link

==> Rebase the code to the latest, and everything got fixed