### PR TITLE
HWIMO-BUILD: Work around npm 1.3.10 bug with prune.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,11 @@ node_modules
 
 # IDE
 .idea
+
+# HWIMO-BUILD artifacts
+on-taskgraph_*.dsc
+on-taskgraph_*.tar.gz
+on-taskgraph_*.build
+on-taskgraph_*.changes
+on-taskgraph_*.deb
+packagebuild

--- a/HWIMO-BUILD
+++ b/HWIMO-BUILD
@@ -10,8 +10,7 @@ git clone . packagebuild
 pushd packagebuild
 
 rm -rf node_modules
-npm install
-npm prune --production
+npm install --production
 git log -n 1 --pretty=format:%h.%ai.%s > commitstring.txt
 
 GITCOMMITDATE=$(git show -s --pretty="format:%ci")


### PR DESCRIPTION
npm prune --production doesn't work correctly in version 1.3.10. It ends up removing the redfish-node module form on-tasks node_modules which is needed for on-taskgraph.

To work around this, we just change the npm install to npm install --production since we prune immediately after the install anyway.