### PR TITLE
Add switch/cisco switch discovery graphs

### DIFF
--- a/lib/graphs/cisco-switch-discovery-graph.js
+++ b/lib/graphs/cisco-switch-discovery-graph.js
@@ -1,0 +1,27 @@
+// Copyright 2016, EMC, Inc.
+
+"use strict";
+
+module.exports = {
+    "friendlyName": "Cisco Switch POAP Discovery",
+    "injectableName": "Graph.Switch.Discovery.Cisco.Poap",
+    "tasks": [
+        {
+            "label": "catalog-switch",
+            "taskDefinition": {
+                "friendlyName": "Catalog Cisco Switch",
+                "injectableName": "Task.Inline.Catalog.Switch.Cisco",
+                "implementsTask": "Task.Base.Linux.Commands",
+                "options": {
+                    "commands": [
+                        {
+                            "downloadUrl": "/api/1.1/templates/cisco-catalog-version.py",
+                            "catalog": { "format": "json", "source": "version" }
+                        }
+                    ]
+                },
+                "properties": {}
+            }
+        }
+    ]
+};

--- a/lib/graphs/switch-active-discovery-sku-graph.js
+++ b/lib/graphs/switch-active-discovery-sku-graph.js
@@ -1,0 +1,82 @@
+// Copyright 2016, EMC, Inc.
+
+"use strict";
+
+module.exports = {
+    "friendlyName": "Active Switch SKU Discovery",
+    "injectableName": "Graph.SKU.Switch.Discovery.Active",
+    "options": {
+        "defaults": {
+            "nodeId": null,
+            "graphOptions": {
+                "target": null
+            },
+        },
+        "vendor-discovery-graph": {
+            "graphName": null
+        }
+    },
+    "tasks": [
+        {
+            "label": "vendor-discovery-graph",
+            "taskDefinition": {
+                "friendlyName": "Run Vendor-specific Switch Discovery",
+                "injectableName": "Task.Graph.Run.Switch.Discovery.VendorSpecific",
+                "implementsTask": "Task.Base.Graph.Run",
+                "options": {
+                    "graphName": null,
+                    "graphOptions": {}
+                },
+                "properties": {}
+            },
+        },
+        {
+            "label": "generate-sku",
+            "waitOn": {
+                "vendor-discovery-graph": "succeeded"
+            },
+            "taskName": "Task.Catalog.GenerateSku"
+        },
+        {
+            "label": "generate-tag",
+            "waitOn": {
+                "vendor-discovery-graph": "succeeded"
+            },
+            "taskName": "Task.Catalog.GenerateTag"
+        },
+        {
+            "label": "run-sku-graph",
+            "taskDefinition": {
+                "friendlyName": "Run SKU-specific graph",
+                "injectableName": "Task.Graph.Run.SkuSpecific",
+                "implementsTask": "Task.Base.Graph.RunSku",
+                "options": {
+                    "nodeId": null
+                },
+                "properties": {}
+            },
+            "waitOn": {
+                "generate-sku": "succeeded"
+            }
+
+        },
+        // NOTE: we have to run any extra commands within another graph so that node
+        // locking can be restricted to inner workflows
+        {
+            "label": "run-sku-post-hooks",
+            "taskDefinition": {
+                "friendlyName": "Run Switch SKU graph post-hooks",
+                "injectableName": "Task.Graph.Run.Switch.Discovery.Hooks.Post",
+                "implementsTask": "Task.Base.Graph.Run",
+                "options": {
+                    "graphName": "Graph.Switch.SKU.Discovery.Hooks.Post",
+                    "graphOptions": {}
+                },
+                "properties": {}
+            },
+            "waitOn": {
+                "run-sku-graph": "succeeded"
+            }
+        }
+    ]
+};

--- a/lib/graphs/switch-discovery-post-sku-hooks-graph.js
+++ b/lib/graphs/switch-discovery-post-sku-hooks-graph.js
@@ -1,0 +1,22 @@
+// Copyright 2016, EMC, Inc.
+
+"use strict";
+
+module.exports = {
+    "friendlyName": "Switch Discovery SKU Graph post-hooks",
+    "injectableName": "Graph.Switch.SKU.Discovery.Hooks.Post",
+    "tasks": [
+        {
+            "label": "exit-switch-taskrunner-success",
+            "taskDefinition": {
+                "friendlyName": "Exit switch taskrunner with success",
+                "injectableName": "Task.Inline.ExitSwitchTaskRunner.Succeeded",
+                "implementsTask": "Task.Base.ShellReboot",
+                "options": {
+                    "rebootCode": 0
+                },
+                "properties": {}
+            }
+        }
+    ]
+};


### PR DESCRIPTION
This PR is one of a few changesets that add functionality for active discovery and configuration of network switches during their bootstrap processes (Cisco POAP, Arista ZTP, etc.). 

I am adding a bundle of what are intended to be RackHD built-in graphs (switch-active-discovery-sku-graph.js and switch-discovery-post-sku-hooks-graph.js) along with some example graphs for cisco cataloging and startup configuration (cisco-switch-discovery-graph.js and deploy-cisco-nexus3000-switch-startup-config-graph.js).

I'll put up a docs PR tomorrow, but the intent of these scripts is that the main switch active discovery graph calls multiple vendor specific sub-graphs. First the cataloging, the implementation of which varies vendor to vendor, and second any SKU-specific graphs that should be run. This is where you do things like specify deploying a startup config and potentially boot images. For example, here's an example SKU definition that can pair with these graphs for Cisco discovery:

```
{
  "name": "Cisco Nexus 3000 Switch - 54 port",
  "rules": [
    {
      "path": "version.chassis_id",
      "regex": "Nexus\\s\\d\\d\\d\\d\\w?\\sChassis"
    },
    {
      "path": "version.module_id",
      "equals": "48x10GT + 6x40G Supervisor"
    }
  ],
  "discoveryGraphName": "Graph.Switch.CiscoNexus3000.DeployStartupConfig",
  "discoveryGraphOptions": {
      "deploy-startup-config": {
          "startupConfig": "example-cisco-startup-config"
      }
  }
}
```

Requires:
https://github.com/RackHD/on-tasks/pull/158

Supports:
https://github.com/RackHD/on-http/pull/210
https://github.com/RackHD/on-dhcp-proxy/pull/32
https://github.com/RackHD/on-skupack/pull/10

FYI @dpasupathi

@RackHD/corecommitters @zyoung51 @heckj @pscharla @VulpesArtificem @johren 