### PR TITLE
Feature/use local package json

### DIFF
--- a/HWIMO-BUILD
+++ b/HWIMO-BUILD
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2015, EMC, Inc.
+# Copyright 2015, 2016, EMC, Inc.
 
 # debian packages expected...
 # apt-get install git pbuilder dh-make ubuntu-dev-tools devscripts

--- a/HWIMO-BUILD
+++ b/HWIMO-BUILD
@@ -6,8 +6,13 @@
 # apt-get install git pbuilder dh-make ubuntu-dev-tools devscripts
 # apt-get install nodejs nodejs-legacy npm
 
+set -e
+set -x
+
+rm -rf packagebuild
 git clone . packagebuild
 pushd packagebuild
+cp ../package.json .
 
 rm -rf node_modules
 npm install --production


### PR DESCRIPTION
This change copies the local package.json file to the packagebuild directory, and does so because that file might be modified during the manifest build to reference dependency modules that are satisfied using references from the manifest file.

For example, the dependency of
```
git+https://github.com/RackHD/on-core.git
```
might be changed to:
```
on-core": "/emc/zuhnd/test-manifest-build/builddir/onrack-test/on-core"
```
during the build process, and then npm will use the version of on-core that's been checked out as per the detailed build manifest.

This change also ensures that errors in the build process are propagated upward (via set -e) so that failures in the ./HWIMO-BUILD process will be noticed upstream.