### PR TITLE
Overwrite kernel and initrd file to 3.13.0 when flashing quanta

### DIFF
--- a/lib/graphs/flash-quanta-all-graph.js
+++ b/lib/graphs/flash-quanta-all-graph.js
@@ -11,7 +11,9 @@ module.exports = {
         },
         'bootstrap-ubuntu': {
             basefs: "common/base.trusty.3.13.0-32.squashfs.img",
-            overlayfs: 'common/overlayfs_quanta_t41_flash-v1.1-3.13.0-32.cpio.gz'
+            overlayfs: 'common/overlayfs_quanta_t41_flash-v1.1-3.13.0-32.cpio.gz',
+            kernelFile: 'vmlinuz-3.13.0-32-generic',
+            initrdFile: 'initrd.img-3.13.0-32-generic'
         },
         'download-megaraid-firmware': {
             file: null
@@ -130,7 +132,7 @@ module.exports = {
         // Post-catalog
         {
             label: 'catalog-quanta-megaraid-after',
-            taskName: 'Task.Catalog.ami',
+            taskName: 'Task.Catalog.megaraid',
             waitOn: {
                 'flash-bmc': 'succeeded'
             }
@@ -144,7 +146,7 @@ module.exports = {
         },
         {
             label: 'catalog-quanta-bmc-after',
-            taskName: 'Task.Catalog.ami',
+            taskName: 'Task.Catalog.bmc',
             waitOn: {
                 'catalog-quanta-bios-after': 'succeeded'
             }

--- a/lib/graphs/flash-quanta-bios-graph.js
+++ b/lib/graphs/flash-quanta-bios-graph.js
@@ -11,7 +11,9 @@ module.exports = {
         },
         "bootstrap-ubuntu": {
             "basefs": "common/base.trusty.3.13.0-32.squashfs.img",
-            "overlayfs": "common/overlayfs_quanta_t41_flash-v1.1-3.13.0-32.cpio.gz"
+            "overlayfs": "common/overlayfs_quanta_t41_flash-v1.1-3.13.0-32.cpio.gz",
+            "kernelFile": "vmlinuz-3.13.0-32-generic",
+            "initrdFile": "initrd.img-3.13.0-32-generic"
         },
         "download-bios-firmware": {
             "file": null

--- a/lib/graphs/flash-quanta-bmc-graph.js
+++ b/lib/graphs/flash-quanta-bmc-graph.js
@@ -63,7 +63,7 @@ module.exports = {
         },
         {
             "label": "catalog-quanta-bmc-after",
-            "taskName": "Task.Catalog.ami",
+            "taskName": "Task.Catalog.bmc",
             "waitOn": {
                 "flash-bmc": "succeeded"
             }


### PR DESCRIPTION
"catalog ami" task before flashing Quanta BIOS would fail in command "./afulnx_64" in microkernel complaining no kernel source exist, thus the following "flash BIOS" task would not be executed. Overwriting the "bootstrap ubuntu" option to 3.13.0 version solve this problem.

Change to use megaraid catalog instead of ami for post-megaraid-update-catalog. Change to use bmc catalog instead of ami for post-bmc-update-catalog.

@benbp 