### PR TITLE
add default 'repo' in install esxi graph

### DIFF
--- a/lib/graphs/install-esx-graph.js
+++ b/lib/graphs/install-esx-graph.js
@@ -8,7 +8,7 @@ module.exports = {
     options: {
         defaults: {
             version: null,
-            repo: null
+            repo: '{{api.server}}/esxi/{{options.version}}'
         },
         'install-os': {
             schedulerOverrides: {


### PR DESCRIPTION
Add default `repo` for install ESXi graph to align with other OSs, such as [RHEL](https://www.github.com/RackHD/on-taskgraph/blob/master/lib/graphs/install-rhel-graph.js#L11), [CentOS](https://www.github.com/RackHD/on-taskgraph/blob/master/lib/graphs/install-centos-graph.js#L11), [SUSE](https://www.github.com/RackHD/on-taskgraph/blob/master/lib/graphs/install-suse-graph.js#L11).

The benefit we get is that if user follows our default address to setup the OS repo, then only the `version` is required for OS bootstrap, such make the OS bootstrap pretty simple.

@RackHD/corecommitters @pengz1 @iceiilin @WangWinson @cgx027 @sunnyqianzhang 