### PR TITLE
 Overwrite kernel and initrd file to 3.13.0 in quanta bmc update workflow

### DIFF
--- a/lib/graphs/flash-quanta-bmc-graph.js
+++ b/lib/graphs/flash-quanta-bmc-graph.js
@@ -11,7 +11,9 @@ module.exports = {
         },
         "bootstrap-ubuntu": {
             "basefs": "common/base.trusty.3.13.0-32.squashfs.img",
-            "overlayfs": "common/overlayfs_quanta_t41_flash-v1.1-3.13.0-32.cpio.gz"
+            "overlayfs": "common/overlayfs_quanta_t41_flash-v1.1-3.13.0-32.cpio.gz",
+            "kernelFile": "vmlinuz-3.13.0-32-generic",
+            "initrdFile": "initrd.img-3.13.0-32-generic"
         },
         "download-bmc-firmware": {
             "file": null
@@ -66,13 +68,6 @@ module.exports = {
             "taskName": "Task.Catalog.bmc",
             "waitOn": {
                 "flash-bmc": "succeeded"
-            }
-        },
-        {
-            "label": "final-reboot",
-            "taskName": "Task.Obm.Node.Reboot",
-            "waitOn": {
-                "catalog-quanta-bmc-after": "finished"
             }
         }
     ]


### PR DESCRIPTION
Overwrite kernel and initrd version to 3.13.0. The tool (soc_flash) for updating BMC is not relied on kernel, while the ipmitool used for catalog before and after updating uses ipmi driver in kernel. 

Remove reboot node task at the end of this workflow. The operation is not a requirement for updating BMC, as suggested in the updating script provided by Quanta. Meanwhile, after updating, BMC network configuration is reset to default (DHCP), so this operation would fail in some network environment, if its IP is not assigned by DHCP server in RackHD control network. Per @zyoung51, there would be a story about saving the configuration before updating and applying it to the new BMC.