### PR TITLE
Dockerfile refactor removes extra node_modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@ Dockerfile
 Gruntfile.js
 HWIMO-*
 LICENSE
+node_modules/
 prototype/
 README.md
 spec/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,21 +2,15 @@
 
 FROM rackhd/on-core
 
-RUN mkdir -p /RackHD/on-taskgraph
+COPY . /RackHD/on-taskgraph/
 WORKDIR /RackHD/on-taskgraph
 
-RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
-    && apk add --update ipmitool@testing net-snmp net-snmp-libs net-snmp-tools
-
-COPY ./package.json /tmp/
-RUN cd /tmp \
-  && ln -s /RackHD/on-core /tmp/node_modules/on-core \
-  && ln -s /RackHD/on-core/node_modules/di /tmp/node_modules/di \
-  && npm install --ignore-scripts --production
-
-COPY . /RackHD/on-taskgraph/
-RUN cp -a -f /tmp/node_modules /RackHD/on-taskgraph/
+RUN mkdir -p ./node_modules \
+  && ln -s /RackHD/on-core ./node_modules/on-core \
+  && ln -s /RackHD/on-core/node_modules/di ./node_modules/di \
+  && npm install --ignore-scripts --production \
+  && echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
+  && apk add --update ipmitool@testing net-snmp net-snmp-libs net-snmp-tools
 
 VOLUME /var/lib/dhcp
-
 CMD [ "node", "/RackHD/on-taskgraph/index.js" ]


### PR DESCRIPTION
Removes extra copy of node_modules directory which reduces the size of the docker image.
