### PR TITLE
added unique flags to indexObject

### DIFF
--- a/lib/task-graph-runner.js
+++ b/lib/task-graph-runner.js
@@ -39,16 +39,6 @@ function runnerFactory(
         this.taskRunner = null;
         this.taskScheduler = null;
         this.completedTaskPoller = null;
-        this.indexObject = {
-            taskdependencies: [
-                {index: {taskId: 1}, unique: true},
-                {index: {graphId: 1}},
-                {index: {taskId: 1, graphId: 1}}
-            ],
-            graphobjects: [
-                {index: {instanceId: 1}, unique: true}
-            ]
-        };
     }
 
     /**
@@ -70,7 +60,7 @@ function runnerFactory(
             return [
                 loader.load(),
                 taskMessenger.start(),
-                store.setIndexes(self.indexObject)
+                store.setIndexes({taskdependencies: [{taskId: 1, graphId: 1}]})
             ];
         })
         .spread(function() {

--- a/lib/task-graph-runner.js
+++ b/lib/task-graph-runner.js
@@ -41,12 +41,12 @@ function runnerFactory(
         this.completedTaskPoller = null;
         this.indexObject = {
             taskdependencies: [
-                {taskId: 1},
-                {graphId: 1},
-                {taskId: 1, graphId: 1}
+                {index: {taskId: 1}, unique: true},
+                {index: {graphId: 1}},
+                {index: {taskId: 1, graphId: 1}}
             ],
             graphobjects: [
-                {instanceId: 1}
+                {index: {instanceId: 1}, unique: true}
             ]
         };
     }


### PR DESCRIPTION
depends on https://github.com/RackHD/on-core/pull/132
changed so that we only create the necessary compound indexes in task-graph-runner; other indexes and uniqueness enforcement have been moved to the waterline models.  
@RackHD/corecommitters 