### PR TITLE
Fix issue with ESXi installation early completion

### DIFF
--- a/lib/graphs/install-esx-graph.js
+++ b/lib/graphs/install-esx-graph.js
@@ -47,10 +47,17 @@ module.exports = {
             }
         },
         {
+            label: 'completion-uri-wait',
+            taskName: 'Task.Wait.Completion.Uri',
+            waitOn: {
+                'install-os': 'succeeded'
+            }
+        },
+        {
             label: "validate-ssh",
             taskName: "Task.Ssh.Validation",
             waitOn: {
-                "install-os": "succeeded"
+                "completion-uri-wait": "succeeded"
             }
         }
     ]


### PR DESCRIPTION
The ESXi installation graph completes during the initial kickstart
download to resolve an issue with multiple reboots.  Add an additional
completionUri wait into the graph to wait for a second Uri trigger
which occurs during the ESXi firstboot script

Resolves https://github.com/RackHD/RackHD/issues/221