### PR TITLE
[1.2] Add task to centos installer that waits for an API call on reboot bef…

### DIFF
--- a/lib/graphs/install-centos-graph.js
+++ b/lib/graphs/install-centos-graph.js
@@ -7,15 +7,23 @@ module.exports = {
     injectableName: 'Graph.InstallCentOS',
     options: {
         defaults: {
+            // Make sure this matches for both the install-os task and the
+            // rackhd-callback-uri-wait task, so put it in "defaults"
+            completionUri: 'renasar-ansible.pub',
             version: null,
             repo: '{{api.server}}/centos/{{options.version}}/os/x86_64'
         },
         'install-os': {
             schedulerOverrides: {
-                timeout: 3600000 //1 hour
+                timeout: 3600000 // 1 hour
             }
         },
-        "validate-ssh": {
+        'rackhd-callback-uri-wait': {
+            schedulerOverrides: {
+                timeout: 1200000 // 20 minutes
+            }
+        },
+        'validate-ssh': {
             retries: 10
         }
     },
@@ -40,10 +48,17 @@ module.exports = {
             }
         },
         {
-            label: "validate-ssh",
-            taskName: "Task.Ssh.Validation",
+            label: 'rackhd-callback-uri-wait',
+            taskName: 'Task.Wait.Completion.Uri',
             waitOn: {
-                "install-os": "succeeded"
+                'install-os': 'succeeded'
+            }
+        },
+        {
+            label: 'validate-ssh',
+            taskName: 'Task.Ssh.Validation',
+            waitOn: {
+                'rackhd-callback-uri-wait': 'succeeded'
             }
         }
     ]


### PR DESCRIPTION
…ore SSH validation

Add an extra task to the CentOS installer that waits until after the reboot stage before doing SSH validation.

Requires RackHD/on-http#280 and RackHD/on-tasks#202

This also depends on @zyoung51's changes to add a completionUri wait task: RackHD/on-tasks#197

@RackHD/corecommitters @heckj @zyoung51 @VulpesArtificem @johren @stuart-stanley