### PR TITLE
Add completion URI wait task to esx installer graph

### DIFF
--- a/lib/graphs/install-esx-graph.js
+++ b/lib/graphs/install-esx-graph.js
@@ -15,6 +15,18 @@ module.exports = {
                 timeout: 3600000 //1 hour
             }
         },
+        'firstboot-callback-uri-wait': {
+            // Different value than for the completionUri for 'install-os'
+            // because we have multiple reboot stages for esx installs
+            completionUri: 'renasar-ansible.pub',
+            $taskTimeout: 1200000 // 20 minutes
+        },
+        'installed-callback-uri-wait': {
+            // There are multiple reboots (we reboot after %firstboot in
+            // the kickstart). Keep track of both before trying to do SSH validation
+            completionUri: 'renasar-ansible.pub',
+            $taskTimeout: 1200000 // 20 minutes
+        },
         'validate-ssh': {
             retries: 10
         }
@@ -47,17 +59,24 @@ module.exports = {
             }
         },
         {
-            label: 'completion-uri-wait',
+            label: 'firstboot-callback-uri-wait',
             taskName: 'Task.Wait.Completion.Uri',
             waitOn: {
                 'install-os': 'succeeded'
             }
         },
         {
-            label: "validate-ssh",
-            taskName: "Task.Ssh.Validation",
+            label: 'installed-callback-uri-wait',
+            taskName: 'Task.Wait.Completion.Uri',
             waitOn: {
-                "completion-uri-wait": "succeeded"
+                'firstboot-callback-uri-wait': 'succeeded'
+            }
+        },
+        {
+            label: 'validate-ssh',
+            taskName: 'Task.Ssh.Validation',
+            waitOn: {
+                'installed-callback-uri-wait': 'succeeded'
             }
         }
     ]


### PR DESCRIPTION
This addresses an issue where we end up doing SSH validation before we're ready during an ESXi install. These changes support a script that hits an API route to verify the OS is up and running during the %firstboot phase of installation and on post installation reboot.

Builds on the update made in https://github.com/RackHD/on-taskgraph/pull/97. ESXi does an extra reboot in our `%firstboot` configuration, so the workflow needs to handle tracking both reboot states in order to avoid doing SSH validation too early (e.g. we might validate the system is up and listening during firstboot right before it reboots, instead of waiting for the last reboot before validation).

Supports https://github.com/RackHD/on-http/pull/282

Requires https://github.com/RackHD/on-tasks/pull/209

@RackHD/corecommitters @heckj @zyoung51 @VulpesArtificem @johren @stuart-stanley @richav1 @amymullins