### PR TITLE
Add SSH validation to RHEL install graph

### DIFF
--- a/lib/graphs/install-rhel-graph.js
+++ b/lib/graphs/install-rhel-graph.js
@@ -7,6 +7,9 @@ module.exports = {
     injectableName: 'Graph.InstallRHEL',
     options: {
         defaults: {
+            // Make sure this matches for both the install-os task and the
+            // rackhd-callback-uri-wait task, so put it in "defaults"
+            completionUri: 'renasar-ansible.pub',
             version: null,
             repo: '{{api.server}}/rhel/{{options.version}}/os/x86_64'
         },
@@ -14,6 +17,14 @@ module.exports = {
             schedulerOverrides: {
                 timeout: 3600000 //1 hour
             }
+        },
+        'rackhd-callback-uri-wait': {
+            schedulerOverrides: {
+                timeout: 1200000 // 20 minutes
+            }
+        },
+        'validate-ssh': {
+            retries: 10
         }
     },
     tasks: [
@@ -34,6 +45,20 @@ module.exports = {
             taskName: 'Task.Os.Install.CentOS', //RHEL installation shares the same task of CentOS
             waitOn: {
                 'reboot': 'succeeded'
+            }
+        },
+        {
+            label: 'rackhd-callback-uri-wait',
+            taskName: 'Task.Wait.Completion.Uri',
+            waitOn: {
+                'install-os': 'succeeded'
+            }
+        },
+        {
+            label: 'validate-ssh',
+            taskName: 'Task.Ssh.Validation',
+            waitOn: {
+                'rackhd-callback-uri-wait': 'succeeded'
             }
         }
     ]


### PR DESCRIPTION
Adds wait for reboot and SSH validation tasks to the RHEL installer graph (identical process to the CentOS installer updates made last week).

@RackHD/corecommitters @heckj @johren @richav1 