### PR TITLE
[1.2] updated switch discovery to update lookups

### DIFF
--- a/lib/graphs/switch-discovery-graph.js
+++ b/lib/graphs/switch-discovery-graph.js
@@ -62,6 +62,13 @@ module.exports = {
             }
         },
         {
+            label: 'update-lookups',
+            taskName: 'Task.Snmp.Update.Lookups',
+            waitOn: {
+                'catalog-snmp': 'succeeded'
+            }
+        },
+        {
             label: 'create-switch-snmp-pollers',
             taskName: 'Task.Pollers.CreateDefault',
             waitOn: {


### PR DESCRIPTION
for RackHD/RackHD#236
@RackHD/corecommitters @johren 
adds a task to the switch discovery workflow to add all of the switch's interface mac addresses to the lookups collection

depends on https://github.com/RackHD/on-tasks/pull/220