### PR TITLE
[1.2] Pull quanta fw update tools instead of using 3.13 microkernel

### DIFF
--- a/lib/graphs/flash-quanta-bios-graph.js
+++ b/lib/graphs/flash-quanta-bios-graph.js
@@ -9,12 +9,6 @@ module.exports = {
         "defaults": {
             "downloadDir": "/opt/downloads"
         },
-        "bootstrap-ubuntu": {
-            "basefs": "common/base.trusty.3.13.0-32.squashfs.img",
-            "overlayfs": "common/overlayfs_quanta_t41_flash-v1.1-3.13.0-32.cpio.gz",
-            "kernelFile": "vmlinuz-3.13.0-32-generic",
-            "initrdFile": "initrd.img-3.13.0-32-generic"
-        },
         "download-bios-firmware": {
             "file": null
         },
@@ -50,10 +44,17 @@ module.exports = {
             }
         },
         {
+            "label": "download-bios-tool",
+            "taskName": "Task.Linux.DownloadAmiTools",
+            "waitOn": {
+                "download-bios-firmware": "succeeded"
+            }
+        },
+        {
             "label": "catalog-quanta-bios-before",
             "taskName": "Task.Catalog.ami",
             "waitOn": {
-                "download-bios-firmware": "succeeded"
+                "download-bios-tool": "succeeded"
             }
         },
         {

--- a/lib/graphs/flash-quanta-bmc-graph.js
+++ b/lib/graphs/flash-quanta-bmc-graph.js
@@ -9,12 +9,6 @@ module.exports = {
         "defaults": {
             "downloadDir": "/opt/downloads"
         },
-        "bootstrap-ubuntu": {
-            "basefs": "common/base.trusty.3.13.0-32.squashfs.img",
-            "overlayfs": "common/overlayfs_quanta_t41_flash-v1.1-3.13.0-32.cpio.gz",
-            "kernelFile": "vmlinuz-3.13.0-32-generic",
-            "initrdFile": "initrd.img-3.13.0-32-generic"
-        },
         "download-bmc-firmware": {
             "file": null
         },
@@ -50,10 +44,17 @@ module.exports = {
             }
         },
         {
+            "label": "download-bmc-tool",
+            "taskName": "Task.Linux.DownloadAmiTools",
+            "waitOn": {
+                "download-bmc-firmware": "succeeded"
+            }
+        },
+        {
             "label": "catalog-quanta-bmc-before",
             "taskName": "Task.Catalog.bmc",
             "waitOn": {
-                "download-bmc-firmware": "succeeded"
+                "download-bmc-tool": "succeeded"
             }
         },
         {

--- a/lib/graphs/flash-quanta-bmc-graph.js
+++ b/lib/graphs/flash-quanta-bmc-graph.js
@@ -70,6 +70,13 @@ module.exports = {
             "waitOn": {
                 "flash-bmc": "succeeded"
             }
+        },
+        {
+            "label": "final-reboot",
+            "taskName": "Task.Obm.Node.Reboot",
+            "waitOn": {
+                "catalog-quanta-bmc-after": "finished"
+            }
         }
     ]
 };

--- a/lib/graphs/write-quanta-bios-nvram-graph.js
+++ b/lib/graphs/write-quanta-bios-nvram-graph.js
@@ -8,9 +8,6 @@ module.exports = {
     options: {
         defaults: {
             file: null
-        },
-        'bootstrap-ubuntu': {
-            overlayfs: 'common/overlayfs_quanta_t41_flash-v1.1-3.13.0-32.cpio.gz'
         }
     },
     tasks: [
@@ -41,12 +38,19 @@ module.exports = {
                 'bootstrap-ubuntu': 'succeeded'
             }
         },
+        {
+            "label": "download-nvram-tool",
+            "taskName": "Task.Linux.DownloadAmiTools",
+            "waitOn": {
+                "download-nvram-settings": "succeeded"
+            }
+        },
         // Write BIOS config settings to nvram
         {
             label: 'nvram-settings',
             taskName :'Task.Linux.SetNvram.Ami',
             waitOn: {
-                'download-nvram-settings': 'succeeded'
+                'download-nvram-tool': 'succeeded'
             }
         },
         // Finish


### PR DESCRIPTION
To address ODR 728, using 3.16 microkernel for FW update, and pulling the necessary tools in a newly-added task.

Another change is to add reboot node after flashing BMC. 
Previous workflow didn't include this step since BMC network restores to default after FW update, and keeping the node in microkernel can help the user to set the BMC LAN settings.
After a restore step has been added to BMC FW update (https://github.com/RackHD/on-http/pull/316, https://github.com/RackHD/on-tasks/pull/221), the reboot task can be added to the workflow.

Details in related PR:
https://github.com/RackHD/on-tasks/pull/221