### PR TITLE
Set service graph status to running.

### DIFF
--- a/lib/service-graph.js
+++ b/lib/service-graph.js
@@ -28,6 +28,9 @@ function ServiceGraph(TaskGraph, store, taskGraphProtocol, Constants, Promise, _
     exports.createAndRunServiceGraph = function(definition, domain) {
         return TaskGraph.create(domain, { definition: definition })
         .then(function(graph) {
+            if (graph._status === Constants.Task.States.Pending) {
+              graph._status = Constants.Task.States.Running;
+            }
             return graph.persist();
         })
         .then(function(graph) {


### PR DESCRIPTION
To improve consistency, since graphs created from on-http will start in a running state. Before the service graphs would be pending.