### PR TITLE
Remove BMC user credentials graph

### DIFF
--- a/lib/graphs/bootstrap-bmc-credentials-remove-graph.js
+++ b/lib/graphs/bootstrap-bmc-credentials-remove-graph.js
@@ -1,0 +1,60 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Bootstrap And Remove BMC Credentials',
+    injectableName: 'Graph.Bootstrap.With.BMC.Credentials.Remove',
+    options: {
+        defaults: {
+            graphOptions: {
+                target: null
+            },
+            nodeId: null,
+        },
+
+    },
+    tasks: [
+        {
+            label: 'boot-graph',
+            taskDefinition: {
+                friendlyName: 'Boot Graph',
+                injectableName: 'Task.Graph.Run.Boot',
+                implementsTask: 'Task.Base.Graph.Run',
+                options: {
+                    graphName: 'Graph.BootstrapUbuntu',
+                    defaults : {
+                        graphOptions: {   }
+                    }
+                },
+                properties: {}
+            }
+        },
+        {
+            label: 'remove-bmc-credentials-graph',
+            taskDefinition: {
+                friendlyName: 'Run BMC Rmove Credential Graph',
+                injectableName: 'Task.Graph.Run.Bmc',
+                implementsTask: 'Task.Base.Graph.Run',
+                options: {
+                    graphName: 'Graph.Remove.Bmc.Credentials',
+                    defaults : {
+                        graphOptions: {   }
+                    }
+                },
+                properties: {}
+            },
+            waitOn: {
+                'boot-graph': 'finished'
+            }
+        },
+        {
+            label: 'finish-bootstrap-trigger',
+            taskName: 'Task.Trigger.Send.Finish',
+            waitOn: {
+                'remove-bmc-credentials-graph': 'finished'
+            }
+        }
+
+    ]
+};

--- a/lib/graphs/remove-bmc-credentials-graph.js
+++ b/lib/graphs/remove-bmc-credentials-graph.js
@@ -1,0 +1,41 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Remove BMC Credentials',
+    injectableName: 'Graph.Remove.Bmc.Credentials',
+    options: {
+        'remove-bmc-credentials': {
+            users: null
+        }
+    },
+    tasks: [
+        {
+            label: 'remove-bmc-credentials',
+            taskName: 'Task.Remove.BMC.Credentials',
+        },
+        {
+            label: 'catalog-bmc',
+            taskName: 'Task.Catalog.bmc',
+            waitOn: {
+                'remove-bmc-credentials': 'succeeded'
+            },
+            ignoreFailure: true
+        },
+        {
+            label: 'shell-reboot',
+            taskName: 'Task.ProcShellReboot',
+            waitOn: {
+                'catalog-bmc': 'finished'
+            }
+        },
+        {
+            label: 'finish-bootstrap-trigger',
+            taskName: 'Task.Trigger.Send.Finish',
+            waitOn: {
+                'catalog-bmc': 'finished'
+            }
+        }
+    ]
+};

--- a/spec/lib/graphs/bootstrap-bmc-credentials-remove-graph-spec.js
+++ b/spec/lib/graphs/bootstrap-bmc-credentials-remove-graph-spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015, EMC, Inc.
+// Copyright 2016, EMC, Inc.
 /* jshint node:true */
 
 'use strict';

--- a/spec/lib/graphs/bootstrap-bmc-credentials-remove-graph-spec.js
+++ b/spec/lib/graphs/bootstrap-bmc-credentials-remove-graph-spec.js
@@ -1,0 +1,17 @@
+// Copyright 2015, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-graph-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/graphs/bootstrap-bmc-credentials-remove-graph.js');
+    });
+
+    describe('graph', function () {
+        base.examples();
+    });
+
+});

--- a/spec/lib/graphs/bootstrap-bmc-credentials-remove-graph-spec.js
+++ b/spec/lib/graphs/bootstrap-bmc-credentials-remove-graph-spec.js
@@ -7,7 +7,8 @@ describe(require('path').basename(__filename), function () {
     var base = require('./base-graph-spec');
 
     base.before(function (context) {
-        context.taskdefinition = helper.require('/lib/graphs/bootstrap-bmc-credentials-remove-graph.js');
+        context.taskdefinition = 
+            helper.require('/lib/graphs/bootstrap-bmc-credentials-remove-graph.js');
     });
 
     describe('graph', function () {

--- a/spec/lib/graphs/remove-bmc-credentials-graph-spec.js
+++ b/spec/lib/graphs/remove-bmc-credentials-graph-spec.js
@@ -1,4 +1,4 @@
-// Copyright 2015, EMC, Inc.
+// Copyright 2016, EMC, Inc.
 /* jshint node:true */
 
 'use strict';

--- a/spec/lib/graphs/remove-bmc-credentials-graph-spec.js
+++ b/spec/lib/graphs/remove-bmc-credentials-graph-spec.js
@@ -1,0 +1,17 @@
+// Copyright 2015, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-graph-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/graphs/remove-bmc-credentials-graph.js');
+    });
+
+    describe('graph', function () {
+        base.examples();
+    });
+
+});


### PR DESCRIPTION
- Allow the user to remove added BMC users to restore defaults
- note: This is part of decommissioning a node story. 

depends on: https://github.com/RackHD/on-tasks/pull/233
depends on: https://github.com/RackHD/on-http/pull/320