### PR TITLE
Node discovered alert

### DIFF
--- a/lib/graphs/discovery-graph.js
+++ b/lib/graphs/discovery-graph.js
@@ -105,6 +105,13 @@ module.exports = {
             waitOn: {
                 'set-boot-pxe': 'finished'
             }
+        },
+        {
+            label: 'node-discovered-alert',
+            taskName: 'Task.Alert.Node.Discovered',
+            waitOn: {
+                'shell-reboot': 'finished'
+            }
         }
     ]
 };

--- a/lib/graphs/discovery-mgmt-graph.js
+++ b/lib/graphs/discovery-mgmt-graph.js
@@ -26,6 +26,14 @@ module.exports = {
                 'catalog-mgmt-lldp': 'finished'
             },
             ignoreFailure: true
+        },
+        {
+            label: 'node-discovered-alert',
+            taskName: 'Task.Alert.Node.Discovered',
+            waitOn: {
+                'catalog-mgmt-dmi': 'finished'
+            }
         }
+
     ]
 };

--- a/lib/graphs/pdu-discovery-graph.js
+++ b/lib/graphs/pdu-discovery-graph.js
@@ -53,6 +53,13 @@ module.exports = {
             waitOn: {
                 'catalog-snmp': 'succeeded'
             }
+        },
+        {
+            label: 'node-discovered-alert',
+            taskName: 'Task.Alert.Node.Discovered',
+            waitOn: {
+                'update-node-name': 'finished'
+            }
         }
     ]
 };

--- a/lib/graphs/switch-discovery-graph.js
+++ b/lib/graphs/switch-discovery-graph.js
@@ -94,6 +94,13 @@ module.exports = {
             waitOn: {
                 'catalog-snmp': 'succeeded'
             }
+        },
+        {
+            label: 'node-discovered-alert',
+            taskName: 'Task.Alert.Node.Discovered',
+            waitOn: {
+                'update-node-name': 'finished'
+            }
         }
     ]
 };


### PR DESCRIPTION
one part of spec https://github.com/RackHD/RackHD/wiki/proposal-AMQP-notifications-on-node-discovery-or-inaccessibility, node remove and inaccessible alert will be in a following PR

depends on PRs: https://github.com/RackHD/on-core/pull/159 and https://github.com/RackHD/on-tasks/pull/240

@RackHD/corecommitters @WangWinson @iceiilin 