### PR TITLE
Modify Graph.Discovery to support sku discovery.

### DIFF
--- a/lib/graphs/discovery-graph.js
+++ b/lib/graphs/discovery-graph.js
@@ -78,17 +78,32 @@ module.exports = {
             ignoreFailure: true
         },
         {
+            "label": "set-boot-pxe",
+            "taskDefinition": {
+                "friendlyName": "Set PXE boot",
+                "injectableName": "Task.Inline.Catalog.Switch.Arista",
+                "implementsTask": "Task.Base.Linux.Commands",
+                "options": {
+		    "commands": "sudo ipmitool chassis bootdev pxe"
+                },
+                "properties": {}
+            },
+            waitOn: {
+               'catalog-lldp': 'finished'
+            }
+        },
+        {
             label: 'shell-reboot',
             taskName: 'Task.ProcShellReboot',
             waitOn: {
-                'catalog-lldp': 'finished'
+                'set-boot-pxe': 'finished'
             }
         },
         {
             label: 'finish-bootstrap-trigger',
             taskName: 'Task.Trigger.Send.Finish',
             waitOn: {
-                'catalog-lldp': 'finished'
+                'set-boot-pxe': 'finished'
             }
         }
     ]

--- a/lib/graphs/discovery-graph.js
+++ b/lib/graphs/discovery-graph.js
@@ -81,10 +81,10 @@ module.exports = {
             "label": "set-boot-pxe",
             "taskDefinition": {
                 "friendlyName": "Set PXE boot",
-                "injectableName": "Task.Inline.Catalog.Switch.Arista",
+                "injectableName": "Task.Node.PxeBoot",
                 "implementsTask": "Task.Base.Linux.Commands",
                 "options": {
-		    "commands": "sudo ipmitool chassis bootdev pxe"
+                    "commands": "sudo ipmitool chassis bootdev pxe"
                 },
                 "properties": {}
             },


### PR DESCRIPTION
Add a task to set bootdev to pxe, so that the following run-sku-graph
will be run following a pxe boot. Please also refer to
lib/graph/discovery-sku-graph.js