### PR TITLE
tweak install-os graph's option to accommodate task-schema upfront validation

### DIFF
--- a/lib/graphs/boot-livecd-graph.js
+++ b/lib/graphs/boot-livecd-graph.js
@@ -6,13 +6,8 @@ module.exports = {
     friendlyName: 'Boot LiveCD',
     injectableName: 'Graph.BootLiveCD',
     options: {
-        defaults: {
-            repo: '{{api.server}}/LiveCD/{{options.version}}'
-        },
         'install-os': {
-            schedulerOverrides: {
-                timeout: 3600000 //1 hour
-            }
+            _taskTimeout: 3600000 //1 hour
         }
     },
     tasks: [

--- a/lib/graphs/install-centos-graph.js
+++ b/lib/graphs/install-centos-graph.js
@@ -9,19 +9,13 @@ module.exports = {
         defaults: {
             // Make sure this matches for both the install-os task and the
             // rackhd-callback-uri-wait task, so put it in "defaults"
-            completionUri: 'renasar-ansible.pub',
-            version: null,
-            repo: '{{api.server}}/centos/{{options.version}}/os/x86_64'
+            completionUri: 'renasar-ansible.pub'
         },
         'install-os': {
-            schedulerOverrides: {
-                timeout: 3600000 // 1 hour
-            }
+            _taskTimeout: 3600000 // 1hour
         },
         'rackhd-callback-uri-wait': {
-            schedulerOverrides: {
-                timeout: 1200000 // 20 minutes
-            }
+            _taskTimeout: 1200000 //20 minutes
         },
         'validate-ssh': {
             retries: 10

--- a/lib/graphs/install-centos-graph.js
+++ b/lib/graphs/install-centos-graph.js
@@ -12,6 +12,7 @@ module.exports = {
             completionUri: 'renasar-ansible.pub'
         },
         'install-os': {
+            version: null,
             _taskTimeout: 3600000 // 1hour
         },
         'rackhd-callback-uri-wait': {

--- a/lib/graphs/install-esx-graph.js
+++ b/lib/graphs/install-esx-graph.js
@@ -11,9 +11,7 @@ module.exports = {
             repo: '{{api.server}}/esxi/{{options.version}}'
         },
         'install-os': {
-            schedulerOverrides: {
-                timeout: 3600000 //1 hour
-            }
+            _taskTimeout: 3600000, //1 hour
         },
         'firstboot-callback-uri-wait': {
             // Different value than for the completionUri for 'install-os'

--- a/lib/graphs/install-rhel-graph.js
+++ b/lib/graphs/install-rhel-graph.js
@@ -9,19 +9,13 @@ module.exports = {
         defaults: {
             // Make sure this matches for both the install-os task and the
             // rackhd-callback-uri-wait task, so put it in "defaults"
-            completionUri: 'renasar-ansible.pub',
-            version: null,
-            repo: '{{api.server}}/rhel/{{options.version}}/os/x86_64'
+            completionUri: 'renasar-ansible.pub'
         },
         'install-os': {
-            schedulerOverrides: {
-                timeout: 3600000 //1 hour
-            }
+            _taskTimeout: 3600000 // 1hour
         },
         'rackhd-callback-uri-wait': {
-            schedulerOverrides: {
-                timeout: 1200000 // 20 minutes
-            }
+            _taskTimeout: 1200000 //20 minutes
         },
         'validate-ssh': {
             retries: 10

--- a/lib/graphs/install-rhel-graph.js
+++ b/lib/graphs/install-rhel-graph.js
@@ -12,6 +12,7 @@ module.exports = {
             completionUri: 'renasar-ansible.pub'
         },
         'install-os': {
+            version: null,
             _taskTimeout: 3600000 // 1hour
         },
         'rackhd-callback-uri-wait': {

--- a/lib/graphs/install-suse-graph.js
+++ b/lib/graphs/install-suse-graph.js
@@ -6,14 +6,8 @@ module.exports = {
     friendlyName: 'Install SUSE',
     injectableName: 'Graph.InstallSUSE',
     options: {
-        defaults: {
-            version: null,
-            repo: '{{api.server}}/distribution/{{options.version}}/repo/oss/'
-        },
         'install-os': {
-            schedulerOverrides: {
-                timeout: 3600000 //1 hour
-            }
+            _taskTimeout: 3600000, //1 hour
         }
     },
     tasks: [

--- a/lib/graphs/install-suse-graph.js
+++ b/lib/graphs/install-suse-graph.js
@@ -7,6 +7,7 @@ module.exports = {
     injectableName: 'Graph.InstallSUSE',
     options: {
         'install-os': {
+            version: null,
             _taskTimeout: 3600000, //1 hour
         }
     },

--- a/spec/lib/graph-library-spec.js
+++ b/spec/lib/graph-library-spec.js
@@ -42,6 +42,7 @@ describe('Graph Library', function () {
             }));
         });
         sinon.stub(env, 'get').resolves({});
+        return helper.injector.get('Services.Task').start();
     });
 
     it("should validate all existing graphs not requiring user input for null values", function() {


### PR DESCRIPTION
When the task-schema upfront validation is enabled, all options in `defaults` will be passed into all tasks, this will cause some error in following case:
for example, if set version & repo to following format:
```
options: {
   defaults: {
     version: null,
     repo: "{{api.server}}/{{options.version}}"
   },
   install-os: { }
}
```

if user passes the workflow options by following format:
```
{
   options: {
      install-os: {
        version: 6.5,
        repo: "xxxxx"
      }
   }
}
```

The `{version: null, repo: "{{api.server}}/{{options.version}}"}` will be passed to all other tasks except install-os. But the actual `version` & `repo` is only passed to 'install-os' tasks. So for all other tasks, the task options rendering will fail as the version is `null` for {{options.version}}.

My change is to remove these kind of data from `defaults`, so the null options will not be passed into every task, then every task can success.

Depend on: https://github.com/RackHD/on-tasks/pull/257, https://github.com/RackHD/on-core/pull/171

@RackHD/corecommitters @WangWinson @iceiilin @cgx027 @pengz1 