### PR TITLE
Race condition in task-graph can cause false success

### DIFF
--- a/lib/graphs/switch-discovery-graph.js
+++ b/lib/graphs/switch-discovery-graph.js
@@ -72,14 +72,14 @@ module.exports = {
             label: 'create-switch-snmp-pollers',
             taskName: 'Task.Pollers.CreateDefault',
             waitOn: {
-                'catalog-snmp': 'succeeded'
+                'update-lookups': 'succeeded'
             }
         },
         {
             label: 'update-node-name',
             taskName: 'Task.Snmp.Node.Update',
             waitOn: {
-                'catalog-snmp': 'succeeded'
+                'create-switch-snmp-pollers': 'succeeded'
             }
         }
     ]


### PR DESCRIPTION
Issue: https://github.com/RackHD/RackHD/issues/295

This is a workaround for this issue for 1.2 only and is targeted at the one graph we use for switches that hit the race condition. All the change does is force the tasks to run in serial.

@RackHD/corecommitters @johren @derrickostertag 
