### PR TITLE
Fix graph completion state race condition when multiple terminal task…

### DIFF
--- a/lib/completed-task-poller.js
+++ b/lib/completed-task-poller.js
@@ -151,7 +151,7 @@ function completedTaskPollerFactory(
                 data.done = true;
                 return Rx.Observable.just(data);
             }
-            return store.checkGraphFinished(data);
+            return store.checkGraphSucceeded(data);
         })
         .flatMap(function(_data) {
             if (_data.done) {

--- a/lib/task-scheduler.js
+++ b/lib/task-scheduler.js
@@ -326,7 +326,7 @@ function taskSchedulerFactory(
         var self = this;
 
         return Rx.Observable.just(data)
-        .flatMap(store.checkGraphFinished.bind(store))
+        .flatMap(store.checkGraphSucceeded.bind(store))
         .filter(function(_data) { return _data.done; })
         .flatMap(store.setGraphDone.bind(store, Constants.Task.States.Succeeded))
         .filter(function(graph) { return !_.isEmpty(graph); })

--- a/spec/lib/completed-task-poller-spec.js
+++ b/spec/lib/completed-task-poller-spec.js
@@ -280,7 +280,7 @@ describe("Completed Task Poller", function() {
 
     describe('handlePotentialFinishedGraph', function() {
         it('should set graph state to failed', function(done) {
-            this.sandbox.stub(store, 'checkGraphFinished').resolves();
+            this.sandbox.stub(store, 'checkGraphSucceeded').resolves();
 
             var data = {
                 state: Constants.Task.States.Failed
@@ -301,7 +301,7 @@ describe("Completed Task Poller", function() {
         });
 
         it('should set graph state to succeeded', function(done) {
-            this.sandbox.stub(store, 'checkGraphFinished', function(_data) {
+            this.sandbox.stub(store, 'checkGraphSucceeded', function(_data) {
                 _data.done = true;
                 return Promise.resolve(_data);
             });
@@ -316,8 +316,8 @@ describe("Completed Task Poller", function() {
 
             poller.handlePotentialFinishedGraph(data)
             .subscribe(subscribeWrapper(done, function() {
-                expect(store.checkGraphFinished).to.have.been.calledOnce;
-                expect(store.checkGraphFinished).to.have.been.calledWith({
+                expect(store.checkGraphSucceeded).to.have.been.calledOnce;
+                expect(store.checkGraphSucceeded).to.have.been.calledWith({
                     done: true,
                     state: Constants.Task.States.Succeeded
                 });
@@ -338,7 +338,7 @@ describe("Completed Task Poller", function() {
         });
 
         it('should do nothing if the graph is not finished', function(done) {
-            this.sandbox.stub(store, 'checkGraphFinished').resolves({ done: false });
+            this.sandbox.stub(store, 'checkGraphSucceeded').resolves({ done: false });
 
             poller.handlePotentialFinishedGraph({ state: Constants.Task.States.Pending })
             .subscribe(subscribeWrapper(done, function() {

--- a/spec/lib/task-scheduler-spec.js
+++ b/spec/lib/task-scheduler-spec.js
@@ -543,8 +543,6 @@ describe('Task Scheduler', function() {
         var observable;
 
         beforeEach(function() {
-            this.sandbox.stub(store, 'setGraphDone');
-            this.sandbox.stub(store, 'checkGraphFinished');
             checkGraphFinishedStream = new Rx.Subject();
             taskScheduler = TaskScheduler.create();
             taskScheduler.running = true;
@@ -628,6 +626,8 @@ describe('Task Scheduler', function() {
 
         it('checkGraphSucceeded should persist and publish on finish', function(done) {
             this.sandbox.stub(taskScheduler, 'publishGraphFinished');
+            this.sandbox.stub(store, 'setGraphDone');
+            this.sandbox.stub(store, 'checkGraphSucceeded');
             taskScheduler.checkGraphSucceeded.restore();
             var data = { graphId: 'testgraphid' };
             var graphData = {
@@ -636,13 +636,13 @@ describe('Task Scheduler', function() {
                 ignoreThisField: 'please'
             };
             var dataDone = { graphId: 'testgraphid', done: true };
-            store.checkGraphFinished.resolves(dataDone);
+            store.checkGraphSucceeded.resolves(dataDone);
             store.setGraphDone.resolves(graphData);
 
             var observable = taskScheduler.checkGraphSucceeded(data);
             streamSuccessWrapper(observable, done, function() {
-                expect(store.checkGraphFinished).to.have.been.calledOnce;
-                expect(store.checkGraphFinished).to.have.been.calledWith(data);
+                expect(store.checkGraphSucceeded).to.have.been.calledOnce;
+                expect(store.checkGraphSucceeded).to.have.been.calledWith(data);
                 expect(store.setGraphDone).to.have.been.calledOnce;
                 expect(store.setGraphDone).to.have.been.calledWith(
                     Constants.Task.States.Succeeded,
@@ -658,6 +658,8 @@ describe('Task Scheduler', function() {
 
         it('checkGraphSucceeded should not set a graph as done if it is not', function(done) {
             this.sandbox.stub(taskScheduler, 'publishGraphFinished');
+            this.sandbox.stub(store, 'setGraphDone');
+            this.sandbox.stub(store, 'checkGraphSucceeded');
             taskScheduler.checkGraphSucceeded.restore();
             var data = { graphId: 'testgraphid' };
             var graphData = {
@@ -666,12 +668,12 @@ describe('Task Scheduler', function() {
                 ignoreThisField: 'please'
             };
             var dataDone = { graphId: 'testgraphid', done: false };
-            store.checkGraphFinished.resolves(dataDone);
+            store.checkGraphSucceeded.resolves(dataDone);
             store.setGraphDone.resolves(graphData);
 
             var observable = taskScheduler.checkGraphSucceeded(data);
             streamCompletedWrapper(observable, done, function() {
-                expect(store.checkGraphFinished).to.have.been.calledOnce;
+                expect(store.checkGraphSucceeded).to.have.been.calledOnce;
                 expect(store.setGraphDone).to.not.have.been.called;
                 expect(taskScheduler.publishGraphFinished).to.not.have.been.called;
             });


### PR DESCRIPTION
…s finish

Fixes https://github.com/RackHD/RackHD/issues/295

If we succeed a terminal task, and fail another terminal task at the same time, there is a race condition where the successful task can trigger a set of the graph to a succeeded state before the failed task can trigger a set to a failed state. This is because the check for whether a graph should be set as successful only includes a check for whether it has no active tasks, rather than no active or failed tasks.

Requires https://github.com/RackHD/on-core/pull/176

This issue can be reproduced (prior to these changes) by running the following graph:

```
{ 
    "friendlyName": "Graph.testrace",
    "injectableName": "Graph.testrace",
    "options": {
        "defaults": {
            "delay": 100
        },
        "4": {
            "delay": 250
        },
        "5": {
            "delay": 250,
            "fail": true
        },
        "6": {
            "delay": 260
        }
    },
    "tasks": [
        { 
            "label": "1", 
            "taskName": "Task.noop" 
        },
        {
          "label": "2",
          "taskName": "Task.noop",
          "waitOn":
            { "1": "succeeded" }
        },
        {
          "label": "3",
          "taskName": "Task.noop",
          "waitOn":
            { "2": "succeeded" }
        },
        {
          "label": "4",
          "taskName": "Task.noop",
          "waitOn":
            { "3": "succeeded" }
        },
        {
          "label": "5",
          "taskName": "Task.noop",
          "waitOn":
            { "3": "succeeded" }
        },
        {
          "label": "6",
          "taskName": "Task.noop",
          "waitOn":
            { "3": "succeeded" }
        }
    ]
}

```

And changing the `_run` function for on-tasks/lib/jobs/noop-job.js to 
```
    NoOpJob.prototype._run = function run() {
        var self = this;
        logger.info("RUNNING NOOP JOB");
        Promise.delay(this.delay).then(function() {
            if (self.options.fail) {
                self._done(new Error("Injected failure"));
                return;
            }
            self._done();
        });
    };
```

@stuart-stanley @RackHD/corecommitters @VulpesArtificem 