### PR TITLE
Move version option from default to install-os task for photon os

### DIFF
--- a/lib/graphs/install-photon-graph.js
+++ b/lib/graphs/install-photon-graph.js
@@ -9,11 +9,10 @@ module.exports = {
         defaults: {
             // Make sure this matches for both the install-os task and the
             // rackhd-callback-uri-wait task, so put it in "defaults"
-            completionUri: 'renasar-ansible.pub',
-            version: null,
-            repo: '{{api.server}}/photon/{{options.version}}'
+            completionUri: 'renasar-ansible.pub'
         },
         'install-os': {
+            version: null,
             schedulerOverrides: {
                 timeout: 3600000 // 1 hour
             }


### PR DESCRIPTION
For Photon installation workflow, version and repo options are only used for "install os" task. Move it out from default so that other task would not bother the render failure problem if the payload set the install-os task only.
@yyscamper @cgx027 