### PR TITLE
Create a discovery Graph that uses docker to run node discovery

### DIFF
--- a/lib/graphs/rancher-discovery-graph.js
+++ b/lib/graphs/rancher-discovery-graph.js
@@ -1,0 +1,117 @@
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Discovery',
+    injectableName: 'Graph.rancherDiscovery',
+    options: {
+        'bootstrap-rancher': {
+            'triggerGroup': 'bootstrap'
+        },
+        'finish-bootstrap-trigger': {
+            'triggerGroup': 'bootstrap'
+        }
+    },
+    tasks: [
+        {
+            label: 'bootstrap-rancher',
+            taskName: 'Task.Linux.Bootstrap.Rancher'
+        },
+        {
+            label: 'catalog-dmi',
+            taskName: 'Task.Catalog.dmi'
+        },
+        {
+            label: 'catalog-ohai',
+            taskName: 'Task.Catalog.ohai',
+            waitOn: {
+                'catalog-dmi': 'finished'
+            }
+        },
+        {
+            label: 'catalog-bmc',
+            taskName: 'Task.Catalog.bmc',
+            waitOn: {
+                'catalog-ohai': 'finished'
+            },
+            ignoreFailure: true
+        },
+        {
+            label: 'catalog-lsall',
+            taskName: 'Task.Catalog.lsall',
+            waitOn: {
+                'catalog-bmc': 'finished'
+            },
+            ignoreFailure: true
+        },
+        {
+            label: 'catalog-megaraid',
+            taskName: 'Task.Catalog.megaraid',
+            waitOn: {
+                'catalog-lsall': 'finished'
+            },
+            ignoreFailure: true
+        },
+        {
+            label: 'catalog-smart',
+            taskName: 'Task.Catalog.smart',
+            waitOn: {
+                'catalog-megaraid': 'finished'
+            },
+            ignoreFailure: true
+        },
+        {
+            label: 'catalog-driveid',
+            taskName: 'Task.Catalog.Drive.Id',
+            waitOn: {
+                'catalog-smart': 'finished'
+            },
+            ignoreFailure: true
+        },
+        {
+            label: 'catalog-lldp',
+            taskName: 'Task.Catalog.LLDP',
+            waitOn: {
+                'catalog-driveid': 'finished'
+            },
+            ignoreFailure: true
+        },
+        {
+            "label": "set-boot-pxe",
+            "taskDefinition": {
+                "friendlyName": "Set PXE boot",
+                "injectableName": "Task.Node.PxeBoot",
+                "implementsTask": "Task.Base.Linux.Commands",
+                "options": {
+                    "commands": "sudo ipmitool chassis bootdev pxe"
+                },
+                "properties": {}
+            },
+            waitOn: {
+               'catalog-lldp': 'finished'
+            }
+        },
+        {
+            label: 'shell-reboot',
+            taskName: 'Task.ProcShellReboot',
+            waitOn: {
+                'set-boot-pxe': 'finished'
+            }
+        },
+        {
+            label: 'finish-bootstrap-trigger',
+            taskName: 'Task.Trigger.Send.Finish',
+            waitOn: {
+                'set-boot-pxe': 'finished'
+            }
+        },
+        {
+            label: 'node-discovered-alert',
+            taskName: 'Task.Alert.Node.Discovered',
+            waitOn: {
+                'shell-reboot': 'finished'
+            }
+        }
+    ]
+};


### PR DESCRIPTION
depends on : https://github.com/RackHD/on-http/pull/392
depends on: https://github.com/RackHD/on-imagebuilder/pull/52/files
depends on : https://github.com/RackHD/on-tasks/pull/293

references:  
- https://osclouds.wordpress.com/2015/11/23/announcing-a-new-docker-based-hanlon-microkernel
- https://groups.google.com/forum/#!topic/rackhd/cSYYxhtPWY0