### PR TITLE
Disable ACPI in kernel

### DIFF
--- a/lib/graphs/discovery-redfish-system-graph.js
+++ b/lib/graphs/discovery-redfish-system-graph.js
@@ -8,8 +8,7 @@ module.exports = {
     options: {
         'bootstrap-ubuntu': {
             'triggerGroup': 'bootstrap',
-            'kernelFile': 'vmlinuz-3.16.0',
-            'initrdFile': 'ramfs.lzma'
+            'kargs': {'acpi':'off'}
         },
         'finish-bootstrap-trigger': {
             'triggerGroup': 'bootstrap'

--- a/lib/graphs/discovery-redfish-system-graph.js
+++ b/lib/graphs/discovery-redfish-system-graph.js
@@ -16,10 +16,6 @@ module.exports = {
         'reboot-start': {
             'obmServiceName': 'redfish-obm-service',
             'force': true
-        },
-        'reboot-end': {
-            'obmServiceName': 'redfish-obm-service',
-            'force': true
         }
     },
     tasks: [
@@ -102,8 +98,8 @@ module.exports = {
             ignoreFailure: true
         },
         {
-            label: 'reboot-end',
-            taskName: 'Task.Obm.Node.Reboot',
+            label: 'shell-reboot',
+            taskName: 'Task.ProcShellReboot',
             waitOn: {
                 'catalog-lldp': 'finished'
             }
@@ -112,7 +108,7 @@ module.exports = {
             label: 'finish-bootstrap-trigger',
             taskName: 'Task.Trigger.Send.Finish',
             waitOn: {
-                'reboot-end': 'finished'
+                'shell-reboot': 'finished'
             }
         },
         {


### PR DESCRIPTION
Temporarily disable ACPI in kernel bootstrap.
Updated to cleanup tasks, replace OBM reset task with shell reboot at the end of discovery.

@RackHD/corecommitters @uppalk1 @zyoung51 @tannoa2 @keedya 