### PR TITLE
Adds docker graphs for listing, running, and stopping containers.

### DIFF
--- a/lib/graphs/docker-ps-graph.js
+++ b/lib/graphs/docker-ps-graph.js
@@ -1,0 +1,22 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+  "friendlyName": "Docker Container List",
+  "injectableName": "Graph.Docker.ListContainers",
+  "options": {
+    "docker-list": {
+      "exec": [
+        {"method": "list", "args": [{"all": 1}],
+          "emit": {"docker-reconciler": {"type": "containers", "ref": 0}}}
+      ]
+    }
+  },
+  "tasks": [
+    {
+      "label": "docker-list",
+      "taskName": 'Task.Docker',
+    }
+  ]
+};

--- a/lib/graphs/docker-restart-graph.js
+++ b/lib/graphs/docker-restart-graph.js
@@ -1,0 +1,22 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+  "friendlyName": "Docker Restart",
+  "injectableName": "Graph.Docker.Restart",
+  "options": {
+    "docker-restart": {
+      "exec": [
+        {"method": "restart", "args": ["{{options.containerId}}", {}]}
+      ],
+      "containerId": "$containerId"
+    }
+  },
+  "tasks": [
+    {
+      "label": "docker-restart",
+      "taskName": "Task.Docker"
+    }
+  ]
+};

--- a/lib/graphs/docker-run-graph.js
+++ b/lib/graphs/docker-run-graph.js
@@ -1,0 +1,24 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+  "friendlyName": "Docker Run",
+  "injectableName": "Graph.Docker.Run",
+  "options": {
+    "docker-run": {
+      "exec": [
+        {"method": "pull", "args": ["{{options.image}}", {}], "then": [
+          {"method": "run", "args": ["{{options.image}}", {}]}
+        ]}
+      ],
+      "image": "ubuntu:latest"
+    }
+  },
+  "tasks": [
+    {
+      "label": "docker-run",
+      "taskName": "Task.Docker"
+    }
+  ]
+};

--- a/lib/graphs/docker-service-graph.js
+++ b/lib/graphs/docker-service-graph.js
@@ -1,0 +1,22 @@
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    "friendlyName": "Docker Service",
+    "injectableName": "Graph.Service.Docker",
+    "serviceGraph": true,
+    "options": {
+        "docker-reconciler": {
+            schedulerOverrides: {
+                timeout: -1
+            }
+        }
+    },
+    "tasks": [
+        {
+            "label": "docker-reconciler",
+            "taskName": "Task.Docker.Reconciler"
+        }
+    ]
+};

--- a/lib/graphs/docker-start-graph.js
+++ b/lib/graphs/docker-start-graph.js
@@ -1,0 +1,22 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+  "friendlyName": "Docker Start",
+  "injectableName": "Graph.Docker.Start",
+  "options": {
+    "docker-start": {
+      "exec": [
+        {"method": "start", "args": ["{{options.containerId}}", {}]}
+      ],
+      "containerId": "$containerId"
+    }
+  },
+  "tasks": [
+    {
+      "label": "docker-start",
+      "taskName": "Task.Docker"
+    }
+  ]
+};

--- a/lib/graphs/docker-stop-graph.js
+++ b/lib/graphs/docker-stop-graph.js
@@ -1,0 +1,22 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+  "friendlyName": "Docker Stop",
+  "injectableName": "Graph.Docker.Stop",
+  "options": {
+    "docker-stop": {
+      "exec": [
+        {"method": "stop", "args": ["{{options.containerId}}", {}]}
+      ],
+      "containerId": "$containerId"
+    }
+  },
+  "tasks": [
+    {
+      "label": "docker-stop",
+      "taskName": "Task.Docker"
+    }
+  ]
+};


### PR DESCRIPTION
Requires `Job.Docker` and `Job.Docker.Reconciler` from: https://github.com/RackHD/on-tasks/pull/296

If you have docker installed and running with RackHD. Create a `local-docker` node with the following structure:

``` json
{
  "name": "local-docker",
  "type": "compute",
  "docker": {
    "hostOptions": {
      "ca": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n",
      "cert": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n",
      "host": "127.0.0.1",
      "key": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----\n",
      "port": 2376,
      "protocol": "https"
    }
  }
}
```

This node will work when running the docker graphs.
