### PR TITLE
docker: Add symlink to ipmitool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN mkdir -p ./node_modules \
   && ln -s /RackHD/on-core/node_modules/di ./node_modules/di \
   && npm install --ignore-scripts --production \
   && echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
-  && apk add --update ipmitool@testing net-snmp net-snmp-libs net-snmp-tools
+  && apk add --update ipmitool@testing net-snmp net-snmp-libs net-snmp-tools \
+  && ln -s /usr/sbin/ipmitool /usr/bin/ipmitool
 
 VOLUME /var/lib/dhcp
 CMD [ "node", "/RackHD/on-taskgraph/index.js" ]


### PR DESCRIPTION
When installing ipmitool on Alpine, it does not go to /usr/bin/ipmitool,
it's in /usr/sbin. As a workaround, add a symlink to it until
RackHD is doing proper $PATH evaluation.

See: https://github.com/RackHD/RackHD/issues/155