### PR TITLE
Update base to rackhd/on-tasks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 # Copyright 2016, EMC, Inc.
 
-FROM rackhd/on-core
+FROM rackhd/on-tasks
 
 COPY . /RackHD/on-taskgraph/
 WORKDIR /RackHD/on-taskgraph
 
 RUN mkdir -p ./node_modules \
+  && ln -s /RackHD/on-tasks ./node_modules/on-tasks \
   && ln -s /RackHD/on-core ./node_modules/on-core \
   && ln -s /RackHD/on-core/node_modules/di ./node_modules/di \
   && npm install --ignore-scripts --production \


### PR DESCRIPTION
Needs: https://github.com/RackHD/on-tasks/pull/318

Changes the base image to `rackhd/on-tasks` so `on-tasks` dependency can be symlinked from `/RackHD/on-tasks`