### PR TITLE
Pass an array of nodeIds to generate-tag task instead of a single nodeId

### DIFF
--- a/lib/graphs/discovery-mgmtsku-graph.js
+++ b/lib/graphs/discovery-mgmtsku-graph.js
@@ -10,7 +10,8 @@ module.exports = {
             graphOptions: {
                 target: null
             },
-            nodeId: null
+            nodeId: null,
+            nodeIds: [ "{{ options.nodeId }}" ]
         }
     },
     tasks: [

--- a/lib/graphs/discovery-sku-graph.js
+++ b/lib/graphs/discovery-sku-graph.js
@@ -10,7 +10,8 @@ module.exports = {
             graphOptions: {
                 target: null
             },
-            nodeId: null
+            nodeId: null,
+            nodeIds: [ "{{ options.nodeId }}" ]
         }
     },
     tasks: [

--- a/lib/graphs/generate-tag-graph.js
+++ b/lib/graphs/generate-tag-graph.js
@@ -7,7 +7,7 @@ module.exports = {
     injectableName: 'Graph.GenerateTags',
     options: {
         "generate-tag": {
-            nodeId: null
+            nodeIds: null
         }
     },
     tasks: [

--- a/lib/graphs/pdu-discovery-graph.js
+++ b/lib/graphs/pdu-discovery-graph.js
@@ -7,7 +7,8 @@ module.exports = {
     injectableName: 'Graph.PDU.Discovery',
     options: {
         defaults: {
-            nodeId: null
+            nodeId: null,
+            nodeIds: [ "{{ options.nodeId }}" ]
         },
         'create-pdu-snmp-pollers': {
             pollers: [

--- a/lib/graphs/switch-active-discovery-sku-graph.js
+++ b/lib/graphs/switch-active-discovery-sku-graph.js
@@ -8,6 +8,7 @@ module.exports = {
     "options": {
         "defaults": {
             "nodeId": null,
+            "nodeIds": [ "{{ options.nodeId }}" ],
             "graphOptions": {
                 "target": null
             },

--- a/lib/graphs/switch-discovery-graph.js
+++ b/lib/graphs/switch-discovery-graph.js
@@ -7,7 +7,8 @@ module.exports = {
     injectableName: 'Graph.Switch.Discovery',
     options: {
         defaults: {
-            nodeId: null
+            nodeId: null,
+            nodeIds: [ "{{ options.nodeId }}" ]
         },
         'create-switch-snmp-pollers': {
             pollers: [


### PR DESCRIPTION
Requires https://github.com/RackHD/on-tasks/pull/320 and https://github.com/RackHD/on-http/pull/442 (interdependent).

@RackHD/corecommitters @heckj @pscharla 