### PR TITLE
Add an index for mongo graphobjects.instanceId

### DIFF
--- a/lib/task-graph-runner.js
+++ b/lib/task-graph-runner.js
@@ -60,7 +60,10 @@ function runnerFactory(
             return [
                 loader.load(),
                 taskMessenger.start(),
-                store.setIndexes({taskdependencies: [{taskId: 1, graphId: 1}]})
+                store.setIndexes({
+                    taskdependencies: [{taskId: 1, graphId: 1}],
+                    graphobjects: [{instanceId: 1}],
+                })
             ];
         })
         .spread(function() {


### PR DESCRIPTION
Given this is our primary lookup field, we should probably index it.

@RackHD/corecommitters @VulpesArtificem @pscharla @zyoung51 @jlongever 