### PR TITLE
fix discovery issue when using static file server

### DIFF
--- a/lib/graphs/bootstrap-decommission-node-graph.js
+++ b/lib/graphs/bootstrap-decommission-node-graph.js
@@ -22,7 +22,7 @@ module.exports = {
             users: null
         },
         'bootstrap-ubuntu': {
-            overlayfs: 'common/secure.erase.overlay.cpio.gz'
+            overlayfsFile: 'secure.erase.overlay.cpio.gz'
         }
     },
     tasks: [

--- a/lib/graphs/examples/bootstrap-ubuntu-inline-graph-example.js
+++ b/lib/graphs/examples/bootstrap-ubuntu-inline-graph-example.js
@@ -29,10 +29,10 @@ module.exports = {
                 implementsTask: 'Task.Base.Linux.Bootstrap',
                 options: {
                     kernelversion: 'vmlinuz-3.13.0-32-generic',
-                    kernel: 'common/vmlinuz-3.13.0-32-generic',
-                    initrd: 'common/initrd.img-3.13.0-32-generic',
-                    basefs: 'common/base.trusty.3.13.0-32.squashfs.img',
-                    overlayfs: 'common/overlayfs_all_files.cpio.gz',
+                    kernelFile: 'vmlinuz-3.13.0-32-generic',
+                    initrdFile: 'initrd.img-3.13.0-32-generic',
+                    basefsFile: 'base.trusty.3.13.0-32.squashfs.img',
+                    overlayfsFile: 'overlayfs_all_files.cpio.gz',
                     profile: 'linux.ipxe'
                 },
                 properties: {

--- a/lib/graphs/examples/bootstrap-ubuntu-mocks-graph.js
+++ b/lib/graphs/examples/bootstrap-ubuntu-mocks-graph.js
@@ -25,7 +25,7 @@ module.exports = {
                 'reboot': 'succeeded'
             },
             optionOverrides: {
-                overlayfs: 'common/overlayfs_all_files.trusty.MOCKS.cpio.gz'
+                overlayfsFile: 'overlayfs_all_files.trusty.MOCKS.cpio.gz'
             }
         }
     ]

--- a/lib/graphs/examples/bootstrap-ubuntu-overrides-graph-example.js
+++ b/lib/graphs/examples/bootstrap-ubuntu-overrides-graph-example.js
@@ -25,7 +25,7 @@ module.exports = {
                 'reboot': 'succeeded'
             },
             optionOverrides: {
-                overlayfs: 'common/overlayfs_all_files.trusty.MOCKS.cpio.gz'
+                overlayfsFile: 'overlayfs_all_files.trusty.MOCKS.cpio.gz'
             }
         }
     ]

--- a/lib/graphs/flash-quanta-all-graph.js
+++ b/lib/graphs/flash-quanta-all-graph.js
@@ -10,8 +10,8 @@ module.exports = {
             downloadDir: '/opt/downloads'
         },
         'bootstrap-ubuntu': {
-            basefs: "common/base.trusty.3.13.0-32.squashfs.img",
-            overlayfs: 'common/overlayfs_quanta_t41_flash-v1.1-3.13.0-32.cpio.gz',
+            basefsFile: "base.trusty.3.13.0-32.squashfs.img",
+            overlayfsFile: 'overlayfs_quanta_t41_flash-v1.1-3.13.0-32.cpio.gz',
             kernelFile: 'vmlinuz-3.13.0-32-generic',
             initrdFile: 'initrd.img-3.13.0-32-generic'
         },

--- a/lib/graphs/flash-quanta-bios-graph.js
+++ b/lib/graphs/flash-quanta-bios-graph.js
@@ -10,8 +10,8 @@ module.exports = {
             "downloadDir": "/opt/downloads"
         },
         "bootstrap-ubuntu": {
-            "basefs": "common/base.trusty.3.13.0-32.squashfs.img",
-            "overlayfs": "common/overlayfs_quanta_t41_flash-v1.1-3.13.0-32.cpio.gz",
+            "basefsFile": "base.trusty.3.13.0-32.squashfs.img",
+            "overlayfsFile": "overlayfs_quanta_t41_flash-v1.1-3.13.0-32.cpio.gz",
             "kernelFile": "vmlinuz-3.13.0-32-generic",
             "initrdFile": "initrd.img-3.13.0-32-generic"
         },

--- a/lib/graphs/flash-quanta-bmc-graph.js
+++ b/lib/graphs/flash-quanta-bmc-graph.js
@@ -10,8 +10,8 @@ module.exports = {
             "downloadDir": "/opt/downloads"
         },
         "bootstrap-ubuntu": {
-            "basefs": "common/base.trusty.3.13.0-32.squashfs.img",
-            "overlayfs": "common/overlayfs_quanta_t41_flash-v1.1-3.13.0-32.cpio.gz",
+            "basefsFile": "base.trusty.3.13.0-32.squashfs.img",
+            "overlayfsFile": "overlayfs_quanta_t41_flash-v1.1-3.13.0-32.cpio.gz",
             "kernelFile": "vmlinuz-3.13.0-32-generic",
             "initrdFile": "initrd.img-3.13.0-32-generic"
         },

--- a/lib/graphs/flash-quanta-megaraid-graph.js
+++ b/lib/graphs/flash-quanta-megaraid-graph.js
@@ -10,8 +10,8 @@ module.exports = {
             "downloadDir": "/opt/downloads"
         },
         "bootstrap-ubuntu": {
-            "basefs": "common/base.trusty.3.13.0-32.squashfs.img",
-            "overlayfs": "common/overlayfs_quanta_t41_flash-v1.1-3.13.0-32.cpio.gz"
+            "basefsFile": "base.trusty.3.13.0-32.squashfs.img",
+            "overlayfsFile": "overlayfs_quanta_t41_flash-v1.1-3.13.0-32.cpio.gz"
         },
         "download-megaraid-firmware": {
             "file": null

--- a/lib/graphs/intel-flashupdt-catalog-graph.js
+++ b/lib/graphs/intel-flashupdt-catalog-graph.js
@@ -7,7 +7,7 @@ module.exports = {
     injectableName: 'Graph.Catalog.Intel.Flashupdt',
     options: {
         'bootstrap-ubuntu': {
-            overlayfs: 'common/overlayfs_intel_flashupdt_syscfg-v1.1-3.13.0-32.cpio.gz'
+            overlayfsFile: 'overlayfs_intel_flashupdt_syscfg-v1.1-3.13.0-32.cpio.gz'
         }
     },
     tasks: [

--- a/lib/graphs/secure-erase-drive-graph.js
+++ b/lib/graphs/secure-erase-drive-graph.js
@@ -7,7 +7,7 @@ module.exports = {
     injectableName: 'Graph.Drive.SecureErase',
     options: {
         'bootstrap-ubuntu': {
-            overlayfs: "common/secure.erase.overlay.cpio.gz",
+            overlayfsFile: "secure.erase.overlay.cpio.gz",
             triggerGroup: 'secureErase'
         },
         'drive-secure-erase': {

--- a/lib/graphs/write-quanta-bios-nvram-graph.js
+++ b/lib/graphs/write-quanta-bios-nvram-graph.js
@@ -10,7 +10,7 @@ module.exports = {
             file: null
         },
         'bootstrap-ubuntu': {
-            overlayfs: 'common/overlayfs_quanta_t41_flash-v1.1-3.13.0-32.cpio.gz'
+            overlayfsFile: 'overlayfs_quanta_t41_flash-v1.1-3.13.0-32.cpio.gz'
         }
     },
     tasks: [


### PR DESCRIPTION
Node discovery fails when using static file server, because basefs and overlayfs are always pulled from API_CB(api.server) rather than file.server.
The solution is to change BASEFS and OVERLAYFS to be full URL instead of file path.
* use overlayfsUri and overlayfsFile to replace overlayfs in task options
* use basefsUri and basefsFile to replace basefs in task options

@RackHD/corecommitters @iceiilin @cgx027 @panpan0000 