### PR TITLE
support install-windows graph schema, allow unit-test passes

### DIFF
--- a/lib/graphs/install-windows-server2012-graph.js
+++ b/lib/graphs/install-windows-server2012-graph.js
@@ -7,11 +7,10 @@ module.exports = {
     injectableName: 'Graph.InstallWindowsServer',
     options: {
         defaults: {
-            version: null,
-            repo: null
+            smbUser: null,
+            smbPassword: null
         }
     },
-
     tasks: [
         {
             label: 'set-boot-pxe',


### PR DESCRIPTION
Actually this file change is just want to make this unit-test ( https://github.com/yyscamper/on-taskgraph/blob/master/spec/lib/graph-library-spec.js#L50 ) happy after task-schema refactor, in the long run, this unit-test need be refactored as well.

@RackHD/corecommitters @iceiilin @cgx027 @pengz1 @lanchongyizu @tannoa2 @amymullins 

jenkins: depends on https://github.com/RackHD/on-core/pull/217, https://github.com/RackHD/on-tasks/pull/360
