### PR TITLE
increase ssh-validation timeout to 60 sec for CentOS install

### DIFF
--- a/lib/graphs/install-centos-graph.js
+++ b/lib/graphs/install-centos-graph.js
@@ -14,7 +14,8 @@ module.exports = {
             _taskTimeout: 1200000 //20 minutes
         },
         'validate-ssh': {
-            retries: 10
+            retries: 10,
+            timeout: 60000
         }
     },
     tasks: [


### PR DESCRIPTION
Increased ssh-validation timeout to fix failing CentOS 7.0 max payload install.  
@keedya @uppalk1 @tannoa2 @RackHD/corecommitters 