### PR TITLE
remove ssh validation from OS installation workflow

### DIFF
--- a/lib/graphs/install-centos-graph.js
+++ b/lib/graphs/install-centos-graph.js
@@ -12,10 +12,6 @@ module.exports = {
         },
         'rackhd-callback-notification-wait': {
             _taskTimeout: 1200000 //20 minutes
-        },
-        'validate-ssh': {
-            retries: 10,
-            timeout: 60000
         }
     },
     tasks: [
@@ -43,13 +39,6 @@ module.exports = {
             taskName: 'Task.Wait.Notification',
             waitOn: {
                 'install-os': 'succeeded'
-            }
-        },
-        {
-            label: 'validate-ssh',
-            taskName: 'Task.Ssh.Validation',
-            waitOn: {
-                'rackhd-callback-notification-wait': 'succeeded'
             }
         }
     ]

--- a/lib/graphs/install-esx-graph.js
+++ b/lib/graphs/install-esx-graph.js
@@ -20,9 +20,6 @@ module.exports = {
             // There are multiple reboots (we reboot after %firstboot in
             // the kickstart). Keep track of both before trying to do SSH validation
             _taskTimeout: 1200000 // 20 minutes
-        },
-        'validate-ssh': {
-            retries: 10
         }
     },
     tasks: [
@@ -64,13 +61,6 @@ module.exports = {
             taskName: 'Task.Wait.Notification',
             waitOn: {
                 'firstboot-callback-notification-wait': 'succeeded'
-            }
-        },
-        {
-            label: 'validate-ssh',
-            taskName: 'Task.Ssh.Validation',
-            waitOn: {
-                'installed-callback-notification-wait': 'succeeded'
             }
         }
     ]

--- a/lib/graphs/install-photon-graph.js
+++ b/lib/graphs/install-photon-graph.js
@@ -16,9 +16,6 @@ module.exports = {
             schedulerOverrides: {
                 timeout: 1200000 // 20 minutes
             }
-        },
-        'validate-ssh': {
-            retries: 10
         }
     },
     tasks: [
@@ -46,13 +43,6 @@ module.exports = {
             taskName: 'Task.Wait.Notification',
             waitOn: {
                 'install-os': 'succeeded'
-            }
-        },
-        {
-            label: 'validate-ssh',
-            taskName: 'Task.Ssh.Validation',
-            waitOn: {
-                'rackhd-callback-notification-wait': 'succeeded'
             }
         }
     ]

--- a/lib/graphs/install-rhel-graph.js
+++ b/lib/graphs/install-rhel-graph.js
@@ -12,9 +12,6 @@ module.exports = {
         },
         'rackhd-callback-notification-wait': {
             _taskTimeout: 1200000 //20 minutes
-        },
-        'validate-ssh': {
-            retries: 10
         }
     },
     tasks: [
@@ -42,13 +39,6 @@ module.exports = {
             taskName: 'Task.Wait.Notification',
             waitOn: {
                 'install-os': 'succeeded'
-            }
-        },
-        {
-            label: 'validate-ssh',
-            taskName: 'Task.Ssh.Validation',
-            waitOn: {
-                'rackhd-callback-notification-wait': 'succeeded'
             }
         }
     ]

--- a/lib/graphs/install-ubuntu-graph.js
+++ b/lib/graphs/install-ubuntu-graph.js
@@ -6,9 +6,6 @@ module.exports = {
     friendlyName: 'Install Ubuntu',
     injectableName: 'Graph.InstallUbuntu',
     options: {
-        "validate-ssh": {
-            retries: 10
-        }
     },
     tasks: [
         {
@@ -35,13 +32,6 @@ module.exports = {
             taskName: 'Task.Wait.Notification',
             waitOn: {
                 'install-ubuntu': 'succeeded'
-            }
-        },
-        {
-            label: "validate-ssh",
-            taskName: "Task.Ssh.Validation",
-            waitOn: {
-                "rackhd-callback-notification-wait": "succeeded"
             }
         }
     ]


### PR DESCRIPTION
Remove ssh validation from OS installation workflow since its funtionality for alerting the completion of OS intallation can be replaced with notification.

@RackHD/corecommitters @panpan0000 @iceiilin @johren @keedya  