### PR TITLE
remove setIndexes to avoid conflict with Model

### DIFF
--- a/lib/task-graph-runner.js
+++ b/lib/task-graph-runner.js
@@ -59,11 +59,7 @@ function runnerFactory(
         .then(function() {
             return [
                 loader.load(),
-                taskMessenger.start(),
-                store.setIndexes({
-                    taskdependencies: [{taskId: 1, graphId: 1}],
-                    graphobjects: [{instanceId: 1}],
-                })
+                taskMessenger.start()
             ];
         })
         .spread(function() {


### PR DESCRIPTION
All index settings will be moved into model, see PR: https://github.com/RackHD/on-core/pull/226

The PR is to remove the index setting in graph runner to avoid the conflict.

@sunnyqianzhang @iceiilin @cgx027 

jenkins: depends on https://github.com/RackHD/on-core/pull/226