### PR TITLE
Remove unecessary graphId info for progress

### DIFF
--- a/lib/task-runner.js
+++ b/lib/task-runner.js
@@ -16,8 +16,7 @@ di.annotate(taskRunnerFactory,
         'Rx',
         'Task.Task',
         'Task.Messenger',
-        'TaskGraph.Store',
-        'TaskGraph.TaskGraph'
+        'TaskGraph.Store'
     )
 );
 
@@ -31,8 +30,7 @@ function taskRunnerFactory(
     Rx,
     Task,
     taskMessenger,
-    store,
-    TaskGraph
+    store
 ) {
     var logger = Logger.initialize(taskRunnerFactory);
 
@@ -398,7 +396,7 @@ function taskRunnerFactory(
             }
         };
         
-        return TaskGraph.updateGraphProgress(task.context.graphId, progressData)
+        return taskMessenger.publishProgressEvent(task.context.graphId, progressData)
         .catch(function(error) {
             logger.error('Error publishing progress event when task started', {
                 taskId: task.instanceId,
@@ -454,7 +452,7 @@ function taskRunnerFactory(
             task.definition.terminalOnStates
         )
         .tap(function(){
-            return TaskGraph.updateGraphProgress(task.context.graphId, progressData);
+            return taskMessenger.publishProgressEvent(task.context.graphId, progressData);
         })
         .catch(function(error) {
             logger.error('Error publishing task finished event', {

--- a/lib/task-runner.js
+++ b/lib/task-runner.js
@@ -388,7 +388,6 @@ function taskRunnerFactory(
                 description: 'Task "' + taskFriendlyName + '" started',
             },
             taskProgress: {
-                graphId: task.context.graphId,
                 taskId: task.instanceId,
                 taskName: taskFriendlyName,
                 progress: {
@@ -425,7 +424,6 @@ function taskRunnerFactory(
                 description: 'Task "' + taskFriendlyName + '" finished',
             },
             taskProgress: {
-                graphId: task.context.graphId,
                 taskId: task.instanceId,
                 taskName: taskFriendlyName,
                 progress: {

--- a/lib/task-runner.js
+++ b/lib/task-runner.js
@@ -60,6 +60,7 @@ function taskRunnerFactory(
         this.activeTasks = {};
         this.lostBeatLimit = options.lostBeatLimit || 3;
         this.domain = options.domain || Constants.Task.DefaultDomain;
+        this.maxTaskProgress = options.totalSteps || 100;
     }
 
     /**
@@ -379,25 +380,25 @@ function taskRunnerFactory(
      * @memberOf TaskRunner
      */
     TaskRunner.prototype.publishTaskStarted = function(task) {
-        var progressData, taskFriendlyName;
-        taskFriendlyName = task.definition.friendlyName;
-        progressData = {
-            graphId: task.context.graphId,
+        var taskFriendlyName = task.definition.friendlyName;
+        var progressData = {
             progress: {
-                percentage: null,
+                value: null,
+                maximum: null,
                 description: 'Task "' + taskFriendlyName + '" started',
             },
             taskProgress: {
                 taskId: task.instanceId,
                 taskName: taskFriendlyName,
                 progress: {
-                    percentage: "0%",
-                    description: "Task started" 
+                    value: 0,
+                    maximum: this.maxTaskProgress,
+                    description: "Task started"
                 }
             }
         };
         
-        return TaskGraph.updateGraphProgress(progressData)
+        return TaskGraph.updateGraphProgress(task.context.graphId, progressData)
         .catch(function(error) {
             logger.error('Error publishing progress event when task started', {
                 taskId: task.instanceId,
@@ -415,20 +416,21 @@ function taskRunnerFactory(
      * @memberOf TaskRunner
      */
     TaskRunner.prototype.publishTaskFinished = function(task) {
-        var errorMsg, progressData, taskFriendlyName;
-        taskFriendlyName = task.definition.friendlyName;
-        progressData = {
-            graphId: task.context.graphId,
+        var errorMsg;
+        var taskFriendlyName = task.definition.friendlyName;
+        var progressData = {
             progress: {
-                percentage: null,
+                value: null,
+                maximum: null,
                 description: 'Task "' + taskFriendlyName + '" finished',
             },
             taskProgress: {
                 taskId: task.instanceId,
                 taskName: taskFriendlyName,
                 progress: {
-                    percentage: "100%",
-                    description: "Task finished" 
+                    value: this.maxTaskProgress,
+                    maximum: this.maxTaskProgress,
+                    description: "Task finished"
                 }
             }
         };
@@ -452,7 +454,7 @@ function taskRunnerFactory(
             task.definition.terminalOnStates
         )
         .tap(function(){
-            return TaskGraph.updateGraphProgress(progressData);
+            return TaskGraph.updateGraphProgress(task.context.graphId, progressData);
         })
         .catch(function(error) {
             logger.error('Error publishing task finished event', {

--- a/spec/lib/task-runner-spec.js
+++ b/spec/lib/task-runner-spec.js
@@ -397,7 +397,6 @@ describe("Task Runner", function() {
                     description: 'Task "' + finishedTask.definition.friendlyName + '" finished'
                 },
                 taskProgress: {
-                    graphId: finishedTask.context.graphId,
                     taskId: finishedTask.instanceId,
                     taskName: finishedTask.definition.friendlyName,
                     progress: {
@@ -479,7 +478,6 @@ describe("Task Runner", function() {
                         description: 'Task "' + startedTask.definition.friendlyName + '" started',
                     },
                     taskProgress: {
-                        graphId: startedTask.context.graphId,
                         taskId: startedTask.instanceId,
                         taskName: startedTask.definition.friendlyName,
                         progress: {

--- a/spec/lib/task-runner-spec.js
+++ b/spec/lib/task-runner-spec.js
@@ -391,18 +391,14 @@ describe("Task Runner", function() {
                 state: 'finished',
                 definition: { terminalOnStates: ['succeeded'], friendlyName: 'Test Task' }};
             progress = {
-                graphId: finishedTask.context.graphId,
                 progress: {
-                    percentage: null,
+                    value: null, maximum: null,
                     description: 'Task "' + finishedTask.definition.friendlyName + '" finished'
                 },
                 taskProgress: {
                     taskId: finishedTask.instanceId,
                     taskName: finishedTask.definition.friendlyName,
-                    progress: {
-                        percentage: "100%",
-                        description: "Task finished" 
-                    }
+                    progress: {value: 100, maximum: 100, description: "Task finished"}
                 }
             };
             runner = TaskRunner.create();
@@ -424,7 +420,8 @@ describe("Task Runner", function() {
                     finishedTask.definition.terminalOnStates
                 );
                 expect(TaskGraph.updateGraphProgress).to.have.been.calledOnce;
-                expect(TaskGraph.updateGraphProgress).to.have.been.calledWith(progress);
+                expect(TaskGraph.updateGraphProgress).to.have.been
+                    .calledWith(finishedTask.context.graphId, progress);
             });
         });
 
@@ -439,7 +436,8 @@ describe("Task Runner", function() {
                 expect(taskMessenger.publishTaskFinished.firstCall.args[4])
                     .to.contain('test error');
                 expect(TaskGraph.updateGraphProgress).to.have.been.calledOnce;
-                expect(TaskGraph.updateGraphProgress).to.have.been.calledWith(progress);
+                expect(TaskGraph.updateGraphProgress).to.have.been
+                    .calledWith(finishedTask.context.graphId, progress);
             });
         });
 
@@ -472,18 +470,14 @@ describe("Task Runner", function() {
                 state: 'Running',
                 definition: { terminalOnStates: ['succeeded'], friendlyName: 'Test Task' }};
             progress = {
-                    graphId: startedTask.context.graphId,
                     progress: {
-                        percentage: null, 
+                        value: null, maximum: null,
                         description: 'Task "' + startedTask.definition.friendlyName + '" started',
                     },
                     taskProgress: {
                         taskId: startedTask.instanceId,
                         taskName: startedTask.definition.friendlyName,
-                        progress: {
-                            percentage: "0%",
-                            description: "Task started" 
-                        }
+                        progress: {value: 0, maximum: 100, description: "Task started"}
                     }
                 };
             this.sandbox.restore();
@@ -495,7 +489,8 @@ describe("Task Runner", function() {
             return runner.publishTaskStarted(startedTask)
             .then(function(){
                 expect(TaskGraph.updateGraphProgress).to.be.calledOnce;
-                expect(TaskGraph.updateGraphProgress).to.be.calledWith(progress);
+                expect(TaskGraph.updateGraphProgress).to.be
+                    .calledWith(startedTask.context.graphId, progress);
             });
         });
 


### PR DESCRIPTION
Jenkins depends on: https://github.com/RackHD/on-core/pull/227, https://github.com/RackHD/on-http/pull/523, https://github.com/RackHD/on-core/pull/227, https://github.com/RackHD/on-tasks/pull/370
This PR is to remove unecessary graphId in task start/finish progress event.