### PR TITLE
Fix periodic race condition in task runner heartbeat test

### DIFF
--- a/spec/lib/task-runner-spec.js
+++ b/spec/lib/task-runner-spec.js
@@ -256,8 +256,8 @@ describe("Task Runner", function() {
 
         it('should heartbeat Tasks on an interval', function(done) {
             runner.running = true;
-            runner.heartbeat = Rx.Observable.interval(1);
-            var heartStream = runner.createHeartbeatSubscription(runner.heartbeat).take(5);
+            runner.heartbeat = Rx.Observable.interval(1).take(5);
+            var heartStream = runner.createHeartbeatSubscription(runner.heartbeat);
             streamOnCompletedWrapper(heartStream, done, function() {
                 expect(store.heartbeatTasksForRunner.callCount).to.equal(5);
             });


### PR DESCRIPTION
Resolves https://github.com/RackHD/RackHD/issues/351

The issue with this test is that the Rx take operator will limit the number of times the `subscribe` callback is called, but not the number of times the methods in the observable pipeline are called, and the test checks the callcount of a stub called in the pipeline. The reason we see the race condition is sometimes the test completes the callcount check fast enough before the next iteration of the 1ms interval we use, and sometimes it doesn't

To understand the Rx behavior, consider the difference between this code:

```
var run = true;

Rx.Observable.interval(1)
.takeWhile(function() {
    return run;
})
.tap(function() {
    console.log('tap');
})
.subscribe(
    function() { run = false; },
    function() {},
    function() { console.log('complete'); }
);
```

Which outputs
```
$ node test.js
tap
complete
```

versus this code:

```
var run = true;

Rx.Observable.interval(1)
.tap(function() {
    console.log('tap');
})
.takeWhile(function() {
    return run;
})
.subscribe(
    function() { run = false; },
    function() {},
    function() { console.log('complete'); }
);
```

Which outputs
```
$ node test.js
tap
tap
```

@RackHD/corecommitters @tldavies @VulpesArtificem @heckj 