### PR TITLE
Add set-bmc task to Discovery

### DIFF
--- a/lib/graphs/discovery-graph.js
+++ b/lib/graphs/discovery-graph.js
@@ -11,6 +11,10 @@ module.exports = {
         },
         'finish-bootstrap-trigger': {
             'triggerGroup': 'bootstrap'
+        },
+        'obm-option' : {
+            obmOption: 'false',
+            when: '{{options.obmOption}}'
         }
     },
     tasks: [
@@ -93,10 +97,65 @@ module.exports = {
             }
         },
         {
+            label: 'obm-option',
+            taskName: 'Task.Evaluate.Condition',
+            waitOn: {
+                'set-boot-pxe': 'finished'
+            },
+            ignoreFailure: true
+        },
+        {
+            label: 'generate-pass',
+            taskDefinition: {
+                friendlyName: 'Generate BMC Password',
+                injectableName: 'Task.Generate.BMC.Password',
+                implementsTask: 'Task.Base.Generate.Password',
+                properties: { },
+                options: {
+                    user: null
+                }
+            },
+            waitOn: {
+                'obm-option': 'succeeded'
+            }
+        },
+        {
+            label: 'set-bmc',
+            taskName: 'Task.Set.BMC.Credentials',
+            waitOn: {
+                'generate-pass': 'succeeded',
+                'obm-option': 'succeeded'
+            }
+        },
+        {
+            label: 'update-catalog-bmc',
+            taskName: 'Task.Catalog.bmc',
+            waitOn: {
+                'set-bmc': 'succeeded',
+                'obm-option': 'succeeded'
+            }
+        },
+        {
+            label: 'create-ipmi-obm-settings',
+            taskName: 'Task.Obm.Ipmi.CreateSettings',
+            waitOn: {
+                'update-catalog-bmc': 'succeeded',
+                'obm-option': 'succeeded'
+            }
+        },
+        {
+            label: 'shell-reboot-post-bmc-settings',
+            taskName: 'Task.ProcShellReboot',
+            waitOn: {
+                'create-ipmi-obm-settings': 'succeeded',
+                'obm-option': 'succeeded'
+            }
+        },
+        {
             label: 'shell-reboot',
             taskName: 'Task.ProcShellReboot',
             waitOn: {
-                'set-boot-pxe': 'finished'
+                'obm-option': 'failed'
             }
         },
         {
@@ -107,10 +166,19 @@ module.exports = {
             }
         },
         {
+            label: 'node-discovered-alert-post-bmc',
+            taskName: 'Task.Alert.Node.Discovered',
+            waitOn: {
+                'create-ipmi-obm-settings': 'finished',
+                'obm-option': 'succeeded'
+            }
+        },
+        {
             label: 'node-discovered-alert',
             taskName: 'Task.Alert.Node.Discovered',
             waitOn: {
-                'shell-reboot': 'finished'
+                'shell-reboot': 'finished',
+                'obm-option': 'failed'
             }
         }
     ]


### PR DESCRIPTION
- Make set obm settings optional and configurable
-  by adding option obmOption: true in rackhd config file