### PR TITLE
add timeout value for cancelTaskGraph

### DIFF
--- a/lib/service-graph.js
+++ b/lib/service-graph.js
@@ -17,7 +17,10 @@ di.annotate(ServiceGraph, new di.Inject(
     )
 );
 function ServiceGraph(TaskGraph, store, taskGraphProtocol, Constants, Promise, _) {
-    var exports = {};
+    var exports = {
+        // Set cancelTaskGraph default timeout
+        timeout: 5000
+    };
 
     /**
      * @param {Object} definition - the JSON graph definition that the TaskGraph
@@ -65,6 +68,7 @@ function ServiceGraph(TaskGraph, store, taskGraphProtocol, Constants, Promise, _
      *   for, cancel them and delete their documents. This is another migration case.
      */
     exports.start = function(domain) {
+        var self = this;
         domain = domain || Constants.Task.DefaultDomain;
 
         return Promise.all([store.getGraphDefinitions(), store.getServiceGraphs()])
@@ -87,7 +91,8 @@ function ServiceGraph(TaskGraph, store, taskGraphProtocol, Constants, Promise, _
                     // Migrate running service graphs if the definition has changed from
                     // the currently active one
                     if (!_.isEqual(activeGraph.definition, def)) {
-                        return taskGraphProtocol.cancelTaskGraph(activeGraph.instanceId)
+                        return taskGraphProtocol.cancelTaskGraph(activeGraph.instanceId,
+                                                                 self.timeout)
                         .then(function() {
                             return store.deleteGraph(groups.running[def.injectableName].instanceId);
                         })
@@ -113,7 +118,7 @@ function ServiceGraph(TaskGraph, store, taskGraphProtocol, Constants, Promise, _
                 // Delete service graphs for which there is no definition
                 // (i.e. migrate old graphs out of existence)
                 return Promise.all(_.map(groups.running, function(graph) {
-                    return taskGraphProtocol.cancelTaskGraph(graph.instanceId)
+                    return taskGraphProtocol.cancelTaskGraph(graph.instanceId, self.timeout)
                     .then(function() {
                         return store.deleteGraph(graph.instanceId);
                     });
@@ -123,10 +128,11 @@ function ServiceGraph(TaskGraph, store, taskGraphProtocol, Constants, Promise, _
     };
 
     exports.stop = function() {
+        var self = this;
         return store.getServiceGraphs()
         .then(function(graphs) {
             return Promise.map(graphs, function(graph) {
-                return taskGraphProtocol.cancelTaskGraph(graph.instanceId);
+                return taskGraphProtocol.cancelTaskGraph(graph.instanceId, self.timeout);
             });
         });
     };

--- a/spec/lib/service-graph-spec.js
+++ b/spec/lib/service-graph-spec.js
@@ -75,9 +75,12 @@ describe('Service Graph', function () {
         return serviceGraph.stop()
         .then(function() {
             expect(taskGraphProtocol.cancelTaskGraph).to.have.been.calledThrice;
-            expect(taskGraphProtocol.cancelTaskGraph).to.have.been.calledWith('testid1');
-            expect(taskGraphProtocol.cancelTaskGraph).to.have.been.calledWith('testid2');
-            expect(taskGraphProtocol.cancelTaskGraph).to.have.been.calledWith('testid3');
+            expect(taskGraphProtocol.cancelTaskGraph)
+                .to.have.been.calledWith('testid1', serviceGraph.timeout);
+            expect(taskGraphProtocol.cancelTaskGraph)
+                .to.have.been.calledWith('testid2', serviceGraph.timeout);
+            expect(taskGraphProtocol.cancelTaskGraph)
+                .to.have.been.calledWith('testid3', serviceGraph.timeout);
         });
     });
 
@@ -140,7 +143,8 @@ describe('Service Graph', function () {
             expect(store.deleteGraph).to.have.been.calledOnce;
             expect(store.deleteGraph).to.have.been.calledWith('testid1');
             expect(taskGraphProtocol.cancelTaskGraph).to.have.been.calledOnce;
-            expect(taskGraphProtocol.cancelTaskGraph).to.have.been.calledWith('testid1');
+            expect(taskGraphProtocol.cancelTaskGraph)
+                .to.have.been.calledWith('testid1', serviceGraph.timeout);
         });
     });
 
@@ -154,7 +158,8 @@ describe('Service Graph', function () {
             expect(store.deleteGraph).to.have.been.calledOnce;
             expect(store.deleteGraph).to.have.been.calledWith('testid1');
             expect(taskGraphProtocol.cancelTaskGraph).to.have.been.calledOnce;
-            expect(taskGraphProtocol.cancelTaskGraph).to.have.been.calledWith('testid1');
+            expect(taskGraphProtocol.cancelTaskGraph)
+                .to.have.been.calledWith('testid1', serviceGraph.timeout);
         });
     });
 


### PR DESCRIPTION
It is found on Jenkins continues test that sometimes on-taskgraph abnormally exits right after starting (about 1 times per day). The error msg is
```
12:52:27 PM graph.1 |  Request Timed Out (on.task-graph-runner:methods.cancelTaskGraph:Object).
12:52:27 PM graph.1 |  RequestTimedOutError: Request Timed Out (on.task-graph-runner:methods.cancelTaskGraph:Object).
12:52:27 PM graph.1 |      at null.<anonymous> (/home/vagrant/src/on-taskgraph/node_modules/on-core/lib/common/messenger.js:361:17)
12:52:27 PM graph.1 |      at Timer.listOnTimeout (timers.js:92:15)
12:52:27 PM graph.1 Exited Abnormally
```
It happened only below two conditions exist at the same time:
1. service graph (poller workflow) in mongoDB is different from current code, so that cancelTaskGraph needs to be called right after RackHD starts to clear previous workflow.
2. when in taskgraph scheduler, one promise is processing the cancel request, while either of the streams (evaluateTask, evaluateGraph or checkGraphFinish) are scheduled to run, which costs more time for the previous promise to finish. 

The default timeout is 1s for all requests in RackHD, and this PR modifies it to 5s for this request. Jenkins continues test has run this patch for 1 week, and the above problem doesn't occur any more.

Theoretically, it is still possible that the timeout value is not enough, especially in scale environment, and service graph has changed after last run. But we could not wait endlessly, neither could we ignore the timeout error, because the code will delete corresponding mongoDB document after cancelling graph.

Jenkins depends on: https://github.com/RackHD/on-core/pull/232