### PR TITLE
Stop TravisCI to upload deb to Bintray - on-taskgraph

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,18 +22,8 @@ services:
 
 after_success:
  - ./extra/make-testcoveralls.sh
-
-before_deploy:
+ # below is the placeholder to leverage TravisCI to verify building capability is good. will be replaced by npm package build.
  - ./extra/make-deb.sh
-
-deploy: 
-  provider: bintray
-  file: .bintray.json
-  user: $BINTRAY_USER
-  key: $BINTRAY_KEY
-  on:
-    branch: master
-    node: "4"
 
 notifications:
   slack:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,10 @@
-on-taskgraph (0.1.1) UNRELEASED; urgency=medium
+on-taskgraph (0.1.5) UNRELEASED; urgency=medium
 
   * release 0.1.0
   * release 0.1.1
+  * release 0.1.5
 
- -- Joe Heck <joseph.heck@emc.com>  Tue, 10 Jan 2017 03:15:26 -0500
+ -- Joe Heck <joseph.heck@emc.com>  Tue, 10 Jan 2017 03:29:03 -0500
 
 on-taskgraph (1.1-1) unstable; urgency=low
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+on-taskgraph (0.1.0) UNRELEASED; urgency=medium
+
+  * release 0.1.0
+
+ -- Joe Heck <joseph.heck@emc.com>  Tue, 10 Jan 2017 03:06:59 -0500
+
 on-taskgraph (1.1-1) unstable; urgency=low
 
   * Initial release

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,9 @@
-on-taskgraph (0.1.0) UNRELEASED; urgency=medium
+on-taskgraph (0.1.1) UNRELEASED; urgency=medium
 
   * release 0.1.0
+  * release 0.1.1
 
- -- Joe Heck <joseph.heck@emc.com>  Tue, 10 Jan 2017 03:06:59 -0500
+ -- Joe Heck <joseph.heck@emc.com>  Tue, 10 Jan 2017 03:15:26 -0500
 
 on-taskgraph (1.1-1) unstable; urgency=low
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "on-taskgraph",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "",
   "main": "lib",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "on-taskgraph",
-  "version": "0.1.1",
+  "version": "0.1.5",
   "description": "",
   "main": "lib",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "on-taskgraph",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "main": "lib",
   "scripts": {


### PR DESCRIPTION
because it's taken over by Jenkins with better version control and tests. 
all background/detail/test , please refer to https://github.com/RackHD/on-tftp/pull/56 for detail.
