### PR TITLE
add vscode config into gitignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ node_modules
 
 # IDE
 .idea
+.vscode/
 
 # HWIMO-BUILD artifacts
 on-taskgraph_*.dsc


### PR DESCRIPTION
Add vscode config file into gitignore list since I am using vscode for remote debugging, it is annoying to see it in "git status".