### PR TITLE
Add an option to make pollers creation on compute node optional

### DIFF
--- a/lib/graphs/discovery-sku-graph.js
+++ b/lib/graphs/discovery-sku-graph.js
@@ -12,6 +12,10 @@ module.exports = {
             },
             nodeId: null,
             nodeIds: [ "{{ options.nodeId }}" ]
+        },
+        'skip-pollers' : {
+            skipPollersCreation: 'false',
+            when: '{{options.skipPollersCreation}}'
         }
     },
     tasks: [
@@ -48,6 +52,14 @@ module.exports = {
                 'discovery-graph': 'succeeded'
             },
             taskName: 'Task.Catalog.GenerateEnclosure',
+            ignoreFailure: true
+        },
+        {
+            label: 'skip-pollers',
+            taskName: 'Task.Evaluate.Condition',
+            waitOn: {
+                'generate-enclosure': 'finished'
+            },
             ignoreFailure: true
         },
         {
@@ -106,7 +118,8 @@ module.exports = {
                 }
             },
             waitOn: {
-                'discovery-graph': 'succeeded'
+                'discovery-graph': 'succeeded',
+                'skip-pollers': 'failed'
             }
         },
         {


### PR DESCRIPTION
- In the future, the same option can be used for other node types