### PR TITLE
Adds repo for snmp-mibs-downloader

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,13 @@ FROM rackhd/on-tasks
 COPY . /RackHD/on-taskgraph/
 WORKDIR /RackHD/on-taskgraph
 
+ADD https://raw.githubusercontent.com/RackHD/on-build-config/master/build-release-tools/docker_sources.list /etc/apt/sources.list
+
 RUN mkdir -p ./node_modules \
   && ln -s /RackHD/on-core ./node_modules/on-core \
   && ln -s /RackHD/on-core/node_modules/di ./node_modules/di \
   && npm install --ignore-scripts --production \
+  && apt-get update \
   && apt-get install -y libsnmp-dev snmp-mibs-downloader snmp \
   && download-mibs
 


### PR DESCRIPTION
Fixes build failures from missing `snmp-mibs-download`

Related PR:
https://github.com/RackHD/on-taskgraph/pull/192
