### PR TITLE
Bugfix: for set bmc credentials

### DIFF
--- a/lib/graphs/discovery-graph.js
+++ b/lib/graphs/discovery-graph.js
@@ -12,9 +12,9 @@ module.exports = {
         'finish-bootstrap-trigger': {
             'triggerGroup': 'bootstrap'
         },
-        'obm-option' : {
-            autoCreateObm: 'false',
-            when: '{{options.autoCreateObm}}'
+        'skip-reboot-post-discovery' : {
+            skipReboot: 'false',
+            when: '{{options.skipReboot}}'
         }
     },
     tasks: [
@@ -97,7 +97,7 @@ module.exports = {
             }
         },
         {
-            label: 'obm-option',
+            label: 'skip-reboot-post-discovery',
             taskName: 'Task.Evaluate.Condition',
             waitOn: {
                 'set-boot-pxe': 'finished'
@@ -105,57 +105,10 @@ module.exports = {
             ignoreFailure: true
         },
         {
-            label: 'generate-pass',
-            taskDefinition: {
-                friendlyName: 'Generate BMC Password',
-                injectableName: 'Task.Generate.BMC.Password',
-                implementsTask: 'Task.Base.Generate.Password',
-                properties: { },
-                options: {
-                    user: null
-                }
-            },
-            waitOn: {
-                'obm-option': 'succeeded'
-            }
-        },
-        {
-            label: 'set-bmc',
-            taskName: 'Task.Set.BMC.Credentials',
-            waitOn: {
-                'generate-pass': 'succeeded',
-                'obm-option': 'succeeded'
-            }
-        },
-        {
-            label: 'update-catalog-bmc',
-            taskName: 'Task.Catalog.bmc',
-            waitOn: {
-                'set-bmc': 'succeeded',
-                'obm-option': 'succeeded'
-            }
-        },
-        {
-            label: 'create-ipmi-obm-settings',
-            taskName: 'Task.Obm.Ipmi.CreateSettings',
-            waitOn: {
-                'update-catalog-bmc': 'succeeded',
-                'obm-option': 'succeeded'
-            }
-        },
-        {
-            label: 'shell-reboot-post-bmc-settings',
-            taskName: 'Task.ProcShellReboot',
-            waitOn: {
-                'create-ipmi-obm-settings': 'succeeded',
-                'obm-option': 'succeeded'
-            }
-        },
-        {
             label: 'shell-reboot',
             taskName: 'Task.ProcShellReboot',
             waitOn: {
-                'obm-option': 'failed'
+                'skip-reboot-post-discovery': 'failed'
             }
         },
         {
@@ -166,19 +119,10 @@ module.exports = {
             }
         },
         {
-            label: 'node-discovered-alert-post-bmc',
-            taskName: 'Task.Alert.Node.Discovered',
-            waitOn: {
-                'create-ipmi-obm-settings': 'finished',
-                'obm-option': 'succeeded'
-            }
-        },
-        {
             label: 'node-discovered-alert',
             taskName: 'Task.Alert.Node.Discovered',
             waitOn: {
-                'shell-reboot': 'finished',
-                'obm-option': 'failed'
+                'finish-bootstrap-trigger': 'finished'
             }
         }
     ]

--- a/lib/graphs/discovery-sku-graph.js
+++ b/lib/graphs/discovery-sku-graph.js
@@ -16,6 +16,10 @@ module.exports = {
         'skip-pollers' : {
             skipPollersCreation: 'false',
             when: '{{options.skipPollersCreation}}'
+        },
+        'obm-option' : {
+            autoCreateObm: 'false',
+            when: '{{options.autoCreateObm}}'
         }
     },
     tasks: [
@@ -32,6 +36,32 @@ module.exports = {
                 properties: {}
             }
         },
+        {
+            label: 'obm-option',
+            taskName: 'Task.Evaluate.Condition',
+            waitOn: {
+               'discovery-graph': 'finished'
+            },
+            ignoreFailure: true
+        },
+        {
+            label: 'set-bmc-credentials-graph',
+            taskDefinition: {
+                friendlyName: 'Run BMC Credential Graph',
+                injectableName: 'Task.Graph.Run.Bmc',
+                implementsTask: 'Task.Base.Graph.Run',
+                options: {
+                    graphName: 'Graph.Set.Bmc.Credentials',
+                    defaults : {
+                        graphOptions: {   }
+                    }
+                },
+                properties: {}
+            },
+            waitOn: {
+                'obm-option': 'succeeded'
+            }
+        }, 
         {
             label: 'generate-sku',
             waitOn: {


### PR DESCRIPTION
- Migrate set bmc credentials from discovery graph to Discovery-sku-graph
  in discovery graph, group label is set in bootstrap
  and it overides the tasks properties

fix for : https://github.com/RackHD/RackHD/issues/602

depends on : https://github.com/RackHD/on-http/pull/578