### PR TITLE
 Update secure erase graph

### DIFF
--- a/lib/graphs/secure-erase-drive-graph.js
+++ b/lib/graphs/secure-erase-drive-graph.js
@@ -7,11 +7,14 @@ module.exports = {
     injectableName: 'Graph.Drive.SecureErase',
     options: {
         'bootstrap-ubuntu': {
-            overlayfsFile: "secure.erase.overlay.cpio.gz",
+            overlayfsFile: 'secure.erase.overlay.cpio.gz',
             triggerGroup: 'secureErase'
         },
         'drive-secure-erase': {
             eraseSettings: null
+        },
+        'drive-scan-delay': {
+            duration: 10000
         },
         'finish-bootstrap-trigger': {
             triggerGroup: 'secureErase'
@@ -19,9 +22,16 @@ module.exports = {
     },
     tasks: [
         {
+            label: 'cache-driveId-catalog',
+            taskName: 'Task.Get.DriveId.Catalog',
+        },
+        {
             label: 'set-boot-pxe',
             taskName: 'Task.Obm.Node.PxeBoot',
-            ignoreFailure: true
+            ignoreFailure: true,
+            waitOn: {
+                'cache-driveId-catalog': 'succeeded'
+            }
         },
         {
             label: 'reboot',
@@ -38,14 +48,35 @@ module.exports = {
             }
         },
         {
-            label: 'drive-secure-erase',
-            taskName: 'Task.Drive.SecureErase',
+            label: 'drive-scan-delay',
+            taskName: 'Task.Node.Sleep',
             waitOn: {
                 'reboot': 'succeeded'
             }
         },
         {
-            label: 'catalog-megaraid',
+            label: 'catalog-driveid-before',
+            taskName: 'Task.Catalog.Drive.Id',
+            waitOn: {
+                'drive-scan-delay': 'succeeded'
+            }
+        },
+        {
+            label: 'catalog-megaraid-before',
+            taskName: 'Task.Catalog.megaraid',
+            waitOn: {
+                'catalog-driveid-before': 'succeeded'
+            }
+        },
+        {
+            label: 'drive-secure-erase',
+            taskName: 'Task.Drive.SecureErase',
+            waitOn: {
+                'catalog-megaraid-before': 'succeeded'
+            }
+        },
+        {
+            label: 'catalog-megaraid-after',
             taskName: 'Task.Catalog.megaraid',
             waitOn: {
                 'drive-secure-erase': 'succeeded'
@@ -53,10 +84,10 @@ module.exports = {
             ignoreFailure: true
         },
         {
-            label: 'catalog-driveid',
+            label: 'catalog-driveid-after',
             taskName: 'Task.Catalog.Drive.Id',
             waitOn: {
-                'catalog-megaraid': 'finished'
+                'catalog-megaraid-after': 'finished'
             },
             ignoreFailure: true
         },
@@ -64,7 +95,7 @@ module.exports = {
             label: 'shell-reboot',
             taskName: 'Task.ProcShellReboot',
             waitOn: {
-                'catalog-driveid': 'finished'
+                'catalog-driveid-after': 'finished'
             }
         },
         {


### PR DESCRIPTION
Jenkins depends on : https://github.com/RackHD/on-tasks/pull/414, https://github.com/RackHD/on-tasks/pull/415, https://github.com/RackHD/on-tasks/pull/408
Secure erase graph is updated based on two considerations:
1. To avoid wrong disk info input by user. If user doesn't use RackHD to do RAID operation, it might happen that user input disk device name doesn't match disk info in existing RackHD catalog. In this case secure erase workflow could erase a disk that user doesn't want to erase.
2. To add delay between OS ready and drives ready. After boot into microkernel, it takes something for OS to scan all disks in the case large quantity of disks are installed on the node. A secure erase task or drive re-cataloging tasks immediately after OS is ready may fail since only part of disks are scanned.

Solutions in the new graph:
1. For the first problem, driveId catalogs will be cached, also driveId and megaraid catalogs will be refreshed before secure erase and compared with cached driveId catalog to identify if  raid configuration is changed. Secure erase will not be executed if catalogs are not identical.
2. For the second problem, a new task is added before re-cataloging tasks, which will delay OS for a user-configurable duration after node boots into microkernel.
