### PR TITLE
Add support for Cisco UCS Service Profile Discovery

### DIFF
--- a/lib/graphs/ucs-service-profile-discovery-graph.js
+++ b/lib/graphs/ucs-service-profile-discovery-graph.js
@@ -1,0 +1,28 @@
+// Copyright 2017, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Ucs Service Profile Discovery',
+    injectableName: 'Graph.Ucs.Service.Profile.Discovery',
+    options: {
+        defaults: {
+            uri: null
+        },
+        'when-catalog-ucs' : {
+            autoCatalogUcs: 'false',
+            when: '{{options.autoCatalogUcs}}'
+        },
+        'when-pollers-ucs' : {
+            autoCreatePollerUcs :'false',
+            when: '{{options.autoCreatePollerUcs}}'
+        }
+    },
+    tasks: [
+        {
+            'x-description': 'Enumerate the ucs service profile',
+            label: 'ucs-service-profile-discovery',
+            taskName: 'Task.Ucs.Service.Profile.Discovery'
+        }
+    ]
+};

--- a/lib/graphs/ucs-service-profile-discovery-graph.js
+++ b/lib/graphs/ucs-service-profile-discovery-graph.js
@@ -9,14 +9,6 @@ module.exports = {
         defaults: {
             uri: null
         },
-        'when-catalog-ucs' : {
-            autoCatalogUcs: 'false',
-            when: '{{options.autoCatalogUcs}}'
-        },
-        'when-pollers-ucs' : {
-            autoCreatePollerUcs :'false',
-            when: '{{options.autoCreatePollerUcs}}'
-        }
     },
     tasks: [
         {

--- a/spec/lib/graphs/ucs-service-profile-discovery-graph-spec.js
+++ b/spec/lib/graphs/ucs-service-profile-discovery-graph-spec.js
@@ -1,0 +1,18 @@
+// Copyright 2017, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-graph-spec');
+
+    base.before(function (context) {
+            context.taskdefinition =
+                helper.require('/lib/graphs/ucs-service-profile-discovery-graph.js');
+        });
+
+    describe('graph', function () {
+            base.examples();
+        });
+
+});


### PR DESCRIPTION
depends on RackHD/on-tasks/pull/420
