### PR TITLE
filter the empty data when graph not found

### DIFF
--- a/lib/task-runner.js
+++ b/lib/task-runner.js
@@ -160,6 +160,7 @@ function taskRunnerFactory(
                         'Error checking out task'))
             .filter(function(data) { return !_.isEmpty(data);})
             .flatMap(self.safeStream.bind(self, store.getTaskById, 'Error fetching task data'))
+            .filter(function(data) { return !_.isEmpty(data);})
             .flatMap(self.runTask.bind(self));
     };
 

--- a/spec/lib/task-runner-spec.js
+++ b/spec/lib/task-runner-spec.js
@@ -195,6 +195,18 @@ describe("Task Runner", function() {
             });
         });
 
+        it('should filter when graph not found', function(done) {
+            runner.running = true;
+            var taskStream = runner.createRunTaskSubscription(Rx.Observable.just(taskAndGraphId));
+            store.getTaskById.resolves(undefined);
+
+            streamOnCompletedWrapper(taskStream, done, function() {
+                expect(store.checkoutTask).to.have.been.calledOnce;
+                expect(store.getTaskById).to.have.been.calledOnce;
+                expect(runner.runTask).to.not.have.been.called;
+            });
+        });
+
         it('should run a task', function(done) {
             runner.running = true;
             this.sandbox.stub(runner, 'handleStreamSuccess');


### PR DESCRIPTION
part of the fix for https://rackhd.atlassian.net/browse/RAC-637 
supports https://github.com/RackHD/on-core/pull/269
@pscharla @RackHD/corecommitters 

If we couldn't get graph the task belongs to it's probably because the graphobjects collection was cleared we're not going to be able to get it, just filter the undefined. 