### PR TITLE
added chef server install graph

### DIFF
--- a/lib/graphs/examples/install-chef-server-graph.js
+++ b/lib/graphs/examples/install-chef-server-graph.js
@@ -1,0 +1,113 @@
+//Copyright © 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Install Chef Server',
+    injectableName: 'Graph.Chef.Install.Server',
+    tasks: [
+        {
+            label: 'sftp-file',
+            taskDefinition: {
+                injectableName: "Task.SftpFile",
+                friendlyName: "Sftp chef core",
+                implementsTask: "Task.Base.Sftp",
+                options: {
+                    fileSource: null,
+                    fileDestination: null
+                },
+                properties: {}
+            }
+        },
+        {
+            label: 'install-chef-core',
+            taskDefinition: {
+                friendlyName: "Install Chef",
+                injectableName: "Task.Chef.InstallCore",
+                implementsTask: "Task.Base.Ssh",
+                options: {
+                    domainName: null,
+                    chefDest: null,
+                    sshExecOptions: null,
+                    installCommand: "sudo dpkg -i",
+                    commands: [
+                        "{{options.installCommand}} {{options.chefDest}}",
+                        "echo '127.0.1.1     {{options.domainName}}'"+
+                        " | sudo tee -a /etc/hosts"
+                    ]
+                },
+                "properties": {}
+            },
+            waitOn: {
+                "sftp-file": "succeeded"
+            }
+        },
+        {
+            label: "reconfigure",
+            taskDefinition: {
+                injectableName: "Task.Run.Client",
+                friendlyName: "Ssh and run Chef client",
+                implementsTask: 'Task.Base.Ssh',
+                options: {
+                    commands: "sudo chef-server-ctl reconfigure"
+                },
+                properties: {}
+            },
+            waitOn: {
+                "install-chef-core": "succeeded"
+            }
+        },
+        {
+            label: "add-user",
+            taskDefinition: {
+                injectableName: "Task.Chef.User.Add",
+                friendlyName: "add user",
+                implementsTask: 'Task.Base.Ssh',
+                options: {
+                    username: null,
+                    firstName: null,
+                    lastName: null,
+                    email: null,
+                    password: null,
+                    userPemFile: null,
+                    commands: [
+                        "chef-server-ctl user-create "+
+                        "{{options.username}} {{options.firstName}} {{options.lastName}} "+
+                        "{{options.email}} {{options.password}}{{#options.userPemFile}}"+
+                        " -f {{options.userPemFile}}{{/options.userPemFile}}"
+                    ]
+                },
+                properties: {}
+            },
+            waitOn: {
+                "reconfigure": "succeeded"
+            }
+        },
+        {
+            label: "add-org",
+            taskDefinition: {
+                injectableName: "Task.Run.Client",
+                friendlyName: "add user",
+                implementsTask: 'Task.Base.Ssh',
+                options: {
+                    sshExecOptions: null,
+                    shortName: null,
+                    fullName: null,
+                    username: null,
+                    validatorPemFile: null,
+                    commands: [
+                        "chef-server-ctl org-create "+
+                        "{{options.shortName}} '{{options.fullName}}'"+
+                        "{{#options.username}} -a {{options.username}}{{/options.username}}"+
+                        "{{#options.validatorPemFile}} -f {{options.validatorPemFile}}"+
+                        "{{/options.validatorPemFile}}"
+                    ]
+                },
+                properties: {}
+            },
+            waitOn: {
+                "add-user": "succeeded"
+            }
+        },
+    ]
+};

--- a/spec/lib/graphs/install-chef-server-graph-spec.js
+++ b/spec/lib/graphs/install-chef-server-graph-spec.js
@@ -1,0 +1,19 @@
+//Copyright © 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-graph-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require(
+            '/lib/graphs/examples/install-chef-server-graph.js'
+        );
+    });
+
+    describe('graph', function () {
+        base.examples();
+    });
+
+});


### PR DESCRIPTION
work in progress for part of https://rackhd.atlassian.net/browse/RI-136
This graph can install and prepare a chef server on a node and subsequently another graph can be run w/ the proper credentials to install the chef client on other nodes and register them with the server. However, at the moment there's not a great place to put the various keys created during the chef-server process so the key-fetching portion isn't automated and if we're going to continue integrating with other services that want some key(s) to be associated with a node it might be a good idea to talk about some kind of database or other encrypted key storage/fetching.
@pscharla @RackHD/corecommitters