### PR TITLE
Fix: graph progress is incorrect when graph failed, timeout or cancelled

### DIFF
--- a/lib/task-runner.js
+++ b/lib/task-runner.js
@@ -339,7 +339,10 @@ function taskRunnerFactory(
                 );
             })
             .tap(function(task) {
-                return graphProgressService.publishTaskStarted(task, {swallowError: true});
+                //The reason to cloneDeep the task is that the method tap in Rxjs is not waited
+                //to finish, and the data flowing into tap is modified by later stream operation.
+                var taskCopy = _.cloneDeep(task);
+                return graphProgressService.publishTaskStarted(taskCopy, {swallowError: true});
             })
             .tap(function(task) {
                 self.activeTasks[task.instanceId] = task;

--- a/lib/task-scheduler.js
+++ b/lib/task-scheduler.js
@@ -253,7 +253,10 @@ function taskSchedulerFactory(
         })
         .filter(function(data) { return data; })
         .tap(function(task){
-            return graphProgressService.publishTaskFinished(task, {swallowError: true});
+            //The reason to cloneDeep the task is that the method tap in Rxjs is not waited
+            //to finish, and the data flowing into tap is modified by later stream operation.
+            var taskCopy = _.cloneDeep(task);
+            return graphProgressService.publishTaskFinished(taskCopy, {swallowError: true});
         })
         .map(self.handleEvaluatedTask.bind(self, checkGraphFinishedStream, evaluateGraphStream));
     };


### PR DESCRIPTION
The original issue is that  graph progress is incorrect when graph failed, timeout or cancelled.

The root cause is that the method `tap` in Rxjs is not waited to finish, and the data flowing into tap is modified by later stream operation.

The solution is `cloneDeep` the `object` to be published.

Recently, https://github.com/RackHD/on-taskgraph/pull/278 has `cloneDeeped` the `graph`, so the problem has been solved in fact. So this updated PR is to `cloneDeep` the remain `objects` to be published.

@RackHD/corecommitters @pengz1 @iceiilin 