### PR TITLE
add api directory in deb

### DIFF
--- a/debian/on-taskgraph.install
+++ b/debian/on-taskgraph.install
@@ -1,4 +1,5 @@
 node_modules /var/renasar/on-taskgraph
 lib /var/renasar/on-taskgraph
+api /var/renasar/on-taskgraph
 index.js /var/renasar/on-taskgraph
 commitstring.txt /var/renasar/on-taskgraph


### PR DESCRIPTION
https://rackhd.atlassian.net/browse/RAC-4863

root cause
https://github.com/RackHD/on-taskgraph/commit/7bfecfe13f0a4fb254333ad59c3826c10a01bbfb

This commit import 
```
require('./api/rpc/index.js'),
```
and other ./api dependency.
But 
```
# on-taskgraph/debian/on-taskgraph.install
node_modules /var/renasar/on-taskgraph
lib /var/renasar/on-taskgraph
index.js /var/renasar/on-taskgraph
commitstring.txt /var/renasar/on-taskgraph
```
doesn't contain ./api directory.

@PengTian0 @panpan0000 