### PR TITLE
Allow scripts to run in npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /RackHD/on-taskgraph
 RUN mkdir -p ./node_modules \
   && ln -s /RackHD/on-core ./node_modules/on-core \
   && ln -s /RackHD/on-core/node_modules/di ./node_modules/di \
-  && npm install --ignore-scripts --production \
+  && npm install --production \
   && apt-get install -y libsnmp-dev snmp-mibs-downloader snmp \
   && download-mibs
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 
 var di = require('di'),
     _ = require('lodash'),
+    consul = require('consul'),
     core = require('on-core')(di),
     helper = core.helper,
     injector = new di.Injector(
@@ -22,7 +23,7 @@ var di = require('di'),
             helper.requireGlob(__dirname + '/lib/services/**/*.js'),
             helper.requireGlob(__dirname + '/api/rest/view/**/*.js'),
             require('./api/rpc/index.js'),
-            helper.requireWrapper('consul', 'consul')
+            helper.simpleWrapper(consul, 'consul')
         ])
     ),
     taskGraphRunner = injector.get('TaskGraph.Runner'),


### PR DESCRIPTION
- ignore-scripts flag applies to all the installed packages.
In this case , part of grps installation is to oompile C code
- requireWrapper default home directory is different in docker
  using singleWrapper instead