### PR TITLE
include data directory to deb

### DIFF
--- a/debian/on-taskgraph.install
+++ b/debian/on-taskgraph.install
@@ -1,5 +1,6 @@
 node_modules /var/renasar/on-taskgraph
 lib /var/renasar/on-taskgraph
 api /var/renasar/on-taskgraph
+data /var/renasar/on-taskgraph
 index.js /var/renasar/on-taskgraph
 commitstring.txt /var/renasar/on-taskgraph


### PR DESCRIPTION
Fix this issue in on-taskgraph deb:
```
0|on-taskg | [error] [2017-04-19T13:05:38.559Z] [on-taskgraph] [DbRenderableContent] [Server] Unable to load views from ../../data/views.
0|on-taskg |  -> /node_modules/on-core/lib/common/db-renderable-content.js:75
0|on-taskg | error: 
0|on-taskg |   cause: 
0|on-taskg |     message: ENOENT: no such file or directory, scandir '../../data/views'
0|on-taskg |     stack: 
0|on-taskg |       - Error: ENOENT: no such file or directory, scandir '../../data/views'
0|on-taskg |       -     at Error (native)
0|on-taskg |   isOperational: true
0|on-taskg |   errno:         -2
0|on-taskg |   code:          ENOENT
0|on-taskg |   syscall:       scandir
0|on-taskg |   path:          ../../data/views
```

@panpan0000 @PengTian0 