### PR TITLE
bugfix: add on-tasks files copy in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY . /RackHD/on-taskgraph/
 WORKDIR /RackHD/on-taskgraph
 
 RUN mkdir -p ./node_modules \
+  && ln -s /RackHD/on-tasks ./node_modules/on-tasks \
   && ln -s /RackHD/on-core ./node_modules/on-core \
   && ln -s /RackHD/on-core/node_modules/di ./node_modules/di \
   && npm install --production \


### PR DESCRIPTION
Add on-tasks files copy in docker build.
Otherwise on-taskgraph will always use the latest on-tasks.

https://rackhd.atlassian.net/browse/RAC-4956

@panpan0000 @PengTian0 