### PR TITLE
modify log format when starting service

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,9 +92,9 @@ taskGraphRunner.start(options)
                  };
                  server = http.createServer(app);
                  server.listen(config.httpPort, config.hostname, function () {
-                     logger.info('Your server is listening on port %d ', config.httpPort);
-                     logger.info('Swagger-ui is available on http://%s:%d/docs', config.hostname,
-                                                                                 config.httpPort);
+                     logger.info('Your server is listening on port %d'.format(config.httpPort));
+                     logger.info('Swagger-ui is available on http://%s:%d/docs'
+                                 .format(config.hostname, config.httpPort));
                  });
              });
         }


### PR DESCRIPTION
When booting on-taskgraph service, previous there is log like
```
[info] [2017-05-24T10:04:39.652Z] [on-taskgraph] [TaskGraph] [Server] Your server is listening on port %d
 -> /index.js:95
[info] [2017-05-24T10:04:39.652Z] [on-taskgraph] [TaskGraph] [Server] Swagger-ui is available on http://%s:%d/docs
 -> /index.js:96
...
```
This PR modifies it to 
```
[info] [2017-05-24T10:01:36.101Z] [on-taskgraph] [TaskGraph] [Server] Your server is listening on port 9005
 -> /index.js:95
[info] [2017-05-24T10:01:36.101Z] [on-taskgraph] [TaskGraph] [Server] Swagger-ui is available on http://0.0.0.0:9005/docs
 -> /index.js:96
```