### PR TITLE
 Remove legacy callback options for run-emc-diag

### DIFF
--- a/lib/graphs/run-emc-diag-graph.js
+++ b/lib/graphs/run-emc-diag-graph.js
@@ -5,11 +5,7 @@
 module.exports = {
     friendlyName: 'Run EMC Diagnostics',
     injectableName: 'Graph.Run.Emc.Diag',
-    options: {
-        'bootstrap-emc-diag': {
-            'completionPath': '/api/common/templates/renasar-ansible.pub'
-        }
-    },
+    options: {},
     tasks: [
         {
             label: 'set-boot-pxe',


### PR DESCRIPTION
Remove legacy options in run-emc-diag-graph.js. Callback has already been replaced by notification API.