### PR TITLE
 Modify run-emc-diag workflow

### DIFF
--- a/lib/graphs/run-emc-diag-graph.js
+++ b/lib/graphs/run-emc-diag-graph.js
@@ -5,16 +5,25 @@
 module.exports = {
     friendlyName: 'Run EMC Diagnostics',
     injectableName: 'Graph.Run.Emc.Diag',
-    options: {},
+    options: {
+        'set-boot-pxe': {
+            "delay": 1000,
+            "retries": 10
+        },
+        'reboot-start': {
+            "delay": 1000,
+            "retries": 10
+        }
+    },
     tasks: [
         {
             label: 'set-boot-pxe',
-            taskName: 'Task.Obm.Node.PxeBoot',
+            taskName: 'Task.Obm.Force.Pxe.Boot',
             ignoreFailure: true
         },
         {
             label: 'reboot-start',
-            taskName: 'Task.Obm.Node.Reboot',
+            taskName: 'Task.Obm.Node.Reset',
             waitOn: {
                 'set-boot-pxe': 'finished'
             }

--- a/spec/lib/graphs/run-emc-diag-graph-spec.js
+++ b/spec/lib/graphs/run-emc-diag-graph-spec.js
@@ -1,0 +1,17 @@
+// Copyright 2017, Dell EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-graph-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/graphs/run-emc-diag-graph.js');
+    });
+
+    describe('graph', function () {
+        base.examples();
+    });
+
+});


### PR DESCRIPTION
Backgroup
Current run-emc-diag workflow is old and not working during our test.

Details
 1. Use force pxe boot task and obm reset to make sure boot flag won't
 be cleared by emc platform rebooting
 2. Add more retries to accommodate emc platform long time BMC
 inaccessibility
 3. Add unit test for the graph.

@nortonluo @iceiilin @anhou 