### PR TITLE
[RAC-5456]add taskName and graphName into on-taskgraph log 

### DIFF
--- a/lib/task-runner.js
+++ b/lib/task-runner.js
@@ -370,9 +370,12 @@ function taskRunnerFactory(
                 delete self.activeTasks[task.instanceId];
             })
             .tap(function(task) {
+
                 return taskMessenger.publishTaskFinished(self.domain, task, true);
             })
-            .map(function(task) { return _.pick(task, ['instanceId', 'state']); })
+            .map(function(task) {
+                 task.taskName = task.definition.injectableName; 
+                 return _.pick(task, ['instanceId', 'taskName', 'state']); })
             .catch(self.handleStreamError.bind(self, 'error while running task'));
     };
 

--- a/lib/task-scheduler.js
+++ b/lib/task-scheduler.js
@@ -42,7 +42,6 @@ function taskSchedulerFactory(
     SchedulerServer,
     Consul,
     graphProgressService
-
 ) {
     var logger = Logger.initialize(taskSchedulerFactory);
     var url = require('url');
@@ -306,7 +305,7 @@ function taskSchedulerFactory(
         .map(self.handleScheduleTaskEvent.bind(self))
         .mergeLossy(self.concurrencyMaximums.handleScheduleTaskEvent)
         .map(function(task) {
-            return _.pick(task, ['domain', 'graphId', 'taskId']);
+            return _.pick(task, ['domain', 'graphId', 'graphName', 'taskId','taskName']);
         });
     };
 
@@ -316,12 +315,26 @@ function taskSchedulerFactory(
      * @param {Object} data
      * @returns {Observable}
      * @memberOf TaskScheduler
-     */
+     */ 
+    TaskScheduler.prototype.getGraphNameAndTaskNameFromDB = function(data){
+        var self = this;
+        var task_data = store.getTaskById(data);
+        return task_data.then(function (res) {
+            return {
+                "domain": self.domain,
+                "taskId": res.task.instanceId,
+                "taskName": res.task.injectableName,
+                "graphId": res.graphId,
+                "graphName": res.context.graphName
+            };
+        });
+    };
     TaskScheduler.prototype.handleScheduleTaskEvent = function(data) {
         var self = this;
         assert.object(data, 'task data object');
-
+         
         return Rx.Observable.just(data)
+        .flatMap(self.getGraphNameAndTaskNameFromDB.bind(self))
         .flatMap(self.publishScheduleTaskEvent.bind(self))
         .catch(self.handleStreamError.bind(self, 'Error scheduling task'));
     };
@@ -598,9 +611,9 @@ function taskSchedulerFactory(
     TaskScheduler.prototype.publishScheduleTaskEvent = function(data) {
         // TODO: Add more scheduling logic here when necessary
         return taskMessenger.publishRunTask(this.domain, data.taskId, data.graphId)
-        .then(function() {
-            return data;
-        });
+                .then(function() {
+                    return data;
+                });
     };
 
     /**


### PR DESCRIPTION
**Background**
The current on-taskgraph log misses task and graph name, which makes developers hard to track workflow's actual behavior. It will be beneficial if adding their name into it. For more details, you can go to https://rackhd.atlassian.net/browse/RAC-5456

**Details**
In on-taskgraph repo, add taskName and graphName in the function taskSchedulerFactory of the file "lib/task-scheduler.js". Besides, change unit test files. The on-taskgraph repo depends on the on-core and on-tasks repo.
Jenkins depends on: https://github.com/RackHD/on-core/pull/285, https://github.com/RackHD/on-tasks/pull/482

**TestDone**
test it successfully on ubuntu 14.04.exsi vm

**Reviewer**
@iceiilin @pengz1