### PR TITLE
Add Racadm Get Firmware list catalog Task into Update firmware Workflow

### DIFF
--- a/lib/graphs/dell-racadm-get-firmware-list-graph.js
+++ b/lib/graphs/dell-racadm-get-firmware-list-graph.js
@@ -4,7 +4,11 @@
 module.exports = {
     friendlyName: 'Dell Racadm Get Firmware List Catalog Graph',
     injectableName: 'Graph.Dell.Racadm.GetFirmwareListCatalog',
-    option: {},
+    options: {
+    "dell-racadm-get-firmware-list-catalog": {
+        "updateExistingCatalog": true
+    }
+},
     tasks: [
         {
             label: 'dell-racadm-get-firmware-list-catalog',

--- a/lib/graphs/dell-racadm-update-firmware-graph.js
+++ b/lib/graphs/dell-racadm-update-firmware-graph.js
@@ -11,6 +11,9 @@ module.exports = {
             serverPassword: null,
             serverFilePath: null
         },
+        'dell-racadm-get-firmware-list-catalog': {
+            'updateExistingCatalog': true
+        },
         'catalog-dmi': {
             updateExistingCatalog: true
         },
@@ -46,10 +49,17 @@ module.exports = {
             }
         },
         {
+            label: 'dell-racadm-get-firmware-list-catalog',
+            taskName: 'Task.Dell.Racadm.GetFirmwareListCatalog',
+            waitOn: {
+                'bootstrap-ubuntu': 'succeeded'
+            }
+        },
+        {
             label: 'catalog-dmi',
             taskName: 'Task.Catalog.dmi',
             waitOn: {
-                'bootstrap-ubuntu': 'succeeded'
+                'dell-racadm-get-firmware-list-catalog': 'succeeded'
             }
         },
         {


### PR DESCRIPTION
Add a capability to set updateExistingCatalog Flag to update existing catalog
instead of creating a fresh catalog each time

Add the Flag in Racadm Get Firmware list Catalog workflow(in case this graph
is run separately from Firmware Upgrade graph)