### PR TITLE
RackHD support to configure RAID on Dell 730 and Quanta

### DIFF
--- a/lib/graphs/dell-perccli-create-megaraid-graph.js
+++ b/lib/graphs/dell-perccli-create-megaraid-graph.js
@@ -62,4 +62,4 @@ module.exports = {
         }
 
     ]
-}
+};

--- a/lib/graphs/dell-perccli-create-megaraid-graph.js
+++ b/lib/graphs/dell-perccli-create-megaraid-graph.js
@@ -4,11 +4,11 @@
 /*jshint multistr: true */
 
 module.exports = {
-    friendlyName: 'Configure Megaraid Controler',
-    injectableName: 'Graph.Bootstrap.Megaraid.Configure',
+    friendlyName: 'Create RAID via perccli',
+    injectableName: 'Graph.Raid.Create.Perccli',
     options: {
         'bootstrap-ubuntu': {
-             overlayfsFile: 'secure.erase.overlay.cpio.gz'
+            overlayfsUri: '{{ api.server }}/common/dell.raid.overlay.cpio.gz'
         },
         'config-raid':{
             hddArr: null,
@@ -20,12 +20,12 @@ module.exports = {
     },
     tasks: [
         {
+            ignoreFailure: true,
             label: 'set-boot-pxe',
-            taskName: 'Task.Obm.Node.PxeBoot',
-            ignoreFailure: true
+            taskName: 'Task.Obm.Node.PxeBoot'
         },
         {
-            label: 'reboot-start',
+            label: 'reboot',
             taskName: 'Task.Obm.Node.Reboot',
             waitOn: {
                 'set-boot-pxe': 'finished'
@@ -35,7 +35,7 @@ module.exports = {
             label: 'bootstrap-ubuntu',
             taskName: 'Task.Linux.Bootstrap.Ubuntu',
             waitOn: {
-                'reboot-start': 'succeeded'
+                'reboot': 'succeeded'
             }
         },
         {
@@ -48,7 +48,7 @@ module.exports = {
         },
         {
             label: 'refresh-catalog-megaraid',
-            taskName: 'Task.Catalog.megaraid',
+            taskName: 'Task.Catalog.perccli',
             waitOn: {
                 'config-raid': 'succeeded'
             }
@@ -60,5 +60,6 @@ module.exports = {
                 'refresh-catalog-megaraid': 'finished'
             }
         }
+
     ]
-};
+}


### PR DESCRIPTION
Signed-off-by: Kranti Uppala <kranti.uppala@emc.com>
Enhance the existing workflows that meets CPSD's FRU replacement guidelines. Works on Quanta and Dell nodes with appropriate payload.

Example payload for quanta:
{
"options": {
"config-raid":{
"ssdStoragePoolArr":[],
"ssdCacheCadeArr":[
{
"enclosure": 252,
"type": "raid0",
"drives":"[0]"
}
],
"controller": 0,
"path":"/opt/MegaRAID/storcli/storcli64",
"hddArr":[
{
"enclosure": 252,
"type": "raid0",
"drives":"[1]"
},
{
"enclosure": 252,
"type": "raid1",
"drives":"[4,5]"
}
]
}
}
}

@RackHD/corecommitters 