### PR TITLE
Fix messy code in on-taskgraph.log

### DIFF
--- a/lib/task-scheduler.js
+++ b/lib/task-scheduler.js
@@ -391,7 +391,12 @@ function taskSchedulerFactory(
                 {swallowError: true}
             );
         })
-        .map(function(graph) { return _.pick(graph, ['instanceId', '_status', 'node', 'name']); })
+        .map(function(graph) {
+            var obj =  _.pick(graph, ['instanceId', '_status', 'node', 'name']);
+            // Change node Id from object to string
+            obj.node = obj.node.toString();
+            return obj;
+        })
         .tap(self._publishGraphFinished.bind(self))
         .catch(self.handleStreamError.bind(self, 'Error handling graph done event'));
     };
@@ -431,7 +436,11 @@ function taskSchedulerFactory(
         .flatMap(store.setGraphDone.bind(store, graphState, data))
         // setGraphDone can return null if another source has already updated
         // the graph state. Don't publish the same event twice.
-        .filter(function(graph) { return graph; })
+        .filter(function(graph) {
+            graph._id = graph._id.toString();
+            graph.node = graph.node.toString();
+            return graph;
+        })
         .tap(self._publishGraphFinished.bind(self))
         .catch(self.handleStreamError.bind(self, 'Error failing/cancelling graph'));
     };


### PR DESCRIPTION
The root cause is, the node info is passed as an object instead of a string to the log, introducing the mess code. Change the type to string to fix this issue. @iceiilin @pengz1 @anhou 

1. Before code change, the node report mess information:
(1.1) For successful task graphs:
[TaskGraph.TaskScheduler] [Server] Graph finished
 -> /lib/task-scheduler.js:527
instanceId:  03be7cf9-803b-41e9-b680-0a421899a7d6
_status:     succeeded
node:
  _bsontype: ObjectID
  id:
    """
      YP½^\^P"H4
      sE<97>
    """
schedulerId: a6d8e8cc-077a-4cf6-8445-2b2aaa161914

(1.2)For failed task graphs:
 [ debug  ] [2017-08-15T08:32:07.214Z] [ec28ce] Graph finished
0|on-taskg |  -> /lib/task-scheduler.js:545
0|on-taskg | _id:                                             ==>the '_id' is a messy
0|on-taskg |   _bsontype: ObjectID
0|on-taskg |   id:        YÂ’Â±Â‡Â¦2ÂšÂ¸Ã¬(ÃŽ
0|on-taskg | _status:        failed
0|on-taskg | node:                                          ==> The 'node' is also a messy
0|on-taskg |   _bsontype: ObjectID
0|on-taskg |   id:        YÂ’Â®Â‹lÃ»)Â•h

2. After code change, it reported the correct node Id.
(2.1) For successful taskgraph:
0|taskgrap | -> /lib/task-scheduler.js:660
0|taskgrap | tasks:
0|taskgrap | - 0ff1d93c-46ba-4a6a-998c-71371fde6171
0|taskgrap | [ debug ] 2017-08-15T07:19:29.610Z Server Graph finished
0|taskgrap | -> /lib/task-scheduler.js:531
0|taskgrap | instanceId: 299c7025-c696-46bf-9a1f-883d153d27f5
0|taskgrap | _status: succeeded
0|taskgrap | node: 5900320b845fb9a161e53901 ==> The node id is expected
0|taskgrap | schedulerId: cf9c4aaf-1cff-49c7-94ab-40fbd5f9d7e7
(2.1) For successful taskgraph:
 -> /lib/task-scheduler.js:549
0|taskgrap | _id:            59953e8943bcae16097b1aff  ==> The graph id is also changed
0|taskgrap | definition:
0|taskgrap | _status:        failed
0|taskgrap | logContext:
0|taskgrap |   graphInstance: 2c02126b-61b4-4902-ad47-aa0812dad374
0|taskgrap |   graphName:     PowerOff Node
0|taskgrap |   id:            5900320b845fb9a161e53901
0|taskgrap | node:           5900320b845fb9a161e53901   ==> The node id correct
0|taskgrap | updatedAt:      Thu Aug 17 2017 02:58:17 GMT-0400 (EDT)
0|taskgrap | createdAt:      Thu Aug 17 2017 02:58:17 GMT-0400 (EDT)
0|taskgrap | schedulerId:    345089bb-c63a-4b54-9d46-eee626159b35

