### PR TITLE
To updte the failed graph status before pulbishing graph fail

### DIFF
--- a/lib/task-scheduler.js
+++ b/lib/task-scheduler.js
@@ -412,17 +412,12 @@ function taskSchedulerFactory(
      */
     TaskScheduler.prototype.failGraph = function(data, graphState) {
         var self = this;
+        var graphToBePublished;
         return Rx.Observable.just(data.graphId)
         .flatMap(store.getActiveGraphById)
         .filter(function(graph) {return !_.isEmpty(graph);})
-        .tap(function(graph) {
-            return graphProgressService.publishGraphFinished(
-                graph,
-                graphState,
-                {swallowError: true}
-            );
-        })
         .map(function(doneGraph) {
+            graphToBePublished = _.cloneDeep(doneGraph);
             return _.map(doneGraph.tasks, function(taskObj) {
                 if(taskObj.state ===  Constants.Task.States.Pending) {
                     taskObj.state = graphState;
@@ -442,6 +437,13 @@ function taskSchedulerFactory(
             return graph;
         })
         .tap(self._publishGraphFinished.bind(self))
+        .tap(function() {
+            return graphProgressService.publishGraphFinished(
+                graphToBePublished,
+                graphState,
+                {swallowError: true}
+            );
+        })
         .catch(self.handleStreamError.bind(self, 'Error failing/cancelling graph'));
     };
 


### PR DESCRIPTION
Before code change, when a taskgraph failed, it will first publish the graph finished event, and then update the taskgraph status. The issue it introduced is that: for the published graph, the status is not yet up-to-date.

The code change is to fix the problem: when a graph failed, change the graph status before publishing the graph finished event.

@pengz1 @iceiilin @lanchongyizu 
Note this code review and the other unmerged code review all changed the file lib/task-schedule.js, whichever one is merged first, the other two need rebase.
 https://github.com/RackHD/on-taskgraph/pull/
https://github.com/RackHD/on-taskgraph/pull/230