### PR TITLE
Fix unit test error caused by modification on on-core

### DIFF
--- a/spec/lib/services/workflow-api-service-spec.js
+++ b/spec/lib/services/workflow-api-service-spec.js
@@ -145,6 +145,7 @@ describe('Taskgraph.Services.Api.Workflows', function () {
             graphId: graph.instanceId,
             graphName: graph.name,
             nodeId: nodeId,
+            status: "running",
             progress: {
                 maximum: 2,
                 value: 0,


### PR DESCRIPTION
jenkins: depends on https://github.com/RackHD/on-core/pull/296
The error found in continuous-integration/travis-ci/pr is expected and could be ignore. When pulling the two dependent PR down and run locally, the issue doesn't exists