### PR TITLE
RAC-5803 Discovery can't be resumed if interrupted in set BMC credentials

### DIFF
--- a/lib/graphs/set-bmc-credentials-graph.js
+++ b/lib/graphs/set-bmc-credentials-graph.js
@@ -9,9 +9,19 @@ module.exports = {
         'generate-pass': {
             user: null,
             password: null
+        },
+        'bootstrap-ubuntu': {
+            'triggerGroup': 'bootstrap'
+        },
+        'finish-bootstrap-trigger': {
+            'triggerGroup': 'bootstrap'
         }
     },
     tasks: [
+        {
+            label: 'bootstrap-ubuntu',
+            taskName: 'Task.Linux.Bootstrap.Ubuntu'
+        },
         {
             label: 'generate-pass',
             taskDefinition: {


### PR DESCRIPTION
**Backgroud**
Discovery can't be resumed if interrupted in set BMC credentials

**Details**
It is found if node discovery (Running 'Graph.SKU.Discovery') is interrupted in set BMC credential stage, discovery can't be consumed and will leave the discovery workflow pending .
SKU discovery graph will execute discovery graph and then set bmc credential graph. And set bmc credential graph leverages microkernel enviroment of discovery workflow. 
Problem is that discovery workflow will send trigger event to finish ubuntu bootstrap task inside it. Thus if interrupt happened (like power cycled) in set bmc credential graph, there is no way that node can boot into ubuntu microkernel again. Discover workflow will always be active until timeout.
An enhancement is required here.

**Reviewers**
@iceiilin  @pengz1
