### PR TITLE
remove lookup for macAddress when call /profiles?macs&&ips

### DIFF
--- a/lib/services/profile-api-service.js
+++ b/lib/services/profile-api-service.js
@@ -23,7 +23,8 @@ di.annotate(profileApiServiceFactory,
         'Profiles',
         'Services.Environment',
         'Http.Services.Swagger',
-        'Constants'
+        'Constants',
+        'Assert'
     )
 );
 function profileApiServiceFactory(
@@ -40,7 +41,8 @@ function profileApiServiceFactory(
     profiles,
     Env,
     swaggerService,
-    Constants
+    Constants,
+    assert
 ) {
 
     var logger = Logger.initialize(profileApiServiceFactory);
@@ -75,35 +77,40 @@ function profileApiServiceFactory(
         return _.flattenDeep([macs]);
     };
 
-    ProfileApiService.prototype.setLookup = function(req, res) {
-        var query = req.swagger ? req.swagger.query : req.query;
+    /**
+     * Get macAddress in HTTP request
+     * @param {Object} query      the query in HTTP request
+     * @param {String} requestIp  the IP of the HTTP request
+     * @return {Promise} Resolves to macAddress if found, otherwise undefined.
+     */
+    ProfileApiService.prototype.getMacAddressInRequest = function(query, requestIp) {
+        assert.object(query);
+        assert.string(requestIp);
 
-        if (!query.macs || !query.ips){
-            return Promise.resolve();
-        }
+        if (query.macs && query.ips) {
+            var macAddresses = _.flattenDeep([query.macs]);
+            var ipAddresses = _.flattenDeep([query.ips]);
 
-        /* Select request's mac and ip, then set them*/
-        var macAddresses = _.flattenDeep([query.macs]);
-        var ipAddresses = _.flattenDeep([query.ips]);
-
-        var index = _.findIndex(ipAddresses, function(ip) {
-            return (ip && (ip === res.locals.ipAddress));
-        });
-
-        if (index < 0 || !macAddresses[index]) {
-            return Promise.resolve();
-        }
-
-        return lookupService.setIpAddress(ipAddresses[index], macAddresses[index])
-            .then(function() {
-                if (req.get(Constants.HttpHeaders.ApiProxyIp)) {
-                    var proxy = 'http://%s:%s'.format(
-                        req.get(Constants.HttpHeaders.ApiProxyIp),
-                        req.get(Constants.HttpHeaders.ApiProxyPort)
-                    );
-                    return waterline.lookups.upsertProxyToMacAddress(proxy, macAddresses[index]);
-                }
+            var index = _.findIndex(ipAddresses, function(ip) {
+                return (ip && (ip === requestIp));
             });
+
+            if(index >= 0 && macAddresses[index]) {
+                return Promise.resolve(macAddresses[index]);
+            }
+        }
+
+        return Promise.resolve();
+    };
+
+    ProfileApiService.prototype.setLookup = function(ipAddress, macAddress, proxyIp, proxyPort) {
+        return lookupService.setIpAddress(ipAddress, macAddress)
+        .then(function() {
+            if (proxyIp) {
+                var proxy = 'http://%s:%s'.format(proxyIp, proxyPort);
+                return waterline.lookups.upsertProxyToMacAddress(proxy, macAddress);
+            }
+        });
     };
 
     ProfileApiService.prototype.getNode = function(macAddresses, options) {
@@ -376,33 +383,44 @@ function profileApiServiceFactory(
 
     ProfileApiService.prototype.getProfiles = function(req, query, res) {
         var self = this;
-        return this.setLookup(req, res)
-            .then(function() {
-                var macs = req.query.mac || req.query.macs;
-                if (macs) {
-                    var macAddresses = self.getMacs(macs);
-                    var options = {
-                        type: 'compute'
-                    };
+        var ipAddress = res.locals.ipAddress;
+        return self.getMacAddressInRequest(query, ipAddress)
+        .then(function(macAddress) {
+            if(macAddress) {
+                res.locals.macAddress = macAddress;
+                var proxyIp = req.get(Constants.HttpHeaders.ApiProxyIp);
+                var proxyPort = req.get(Constants.HttpHeaders.ApiProxyPort);
+                return self.setLookup(ipAddress, macAddress, proxyIp, proxyPort);
+            }
+        })
+        .then(function() {
+            var macs = query.mac || query.macs;
+            if (macs) {
+                var macAddresses = self.getMacs(macs);
+                var options = {
+                    type: 'compute'
+                };
 
-                    return self.getNode(macAddresses, options)
-                        .then(function (node) {
-                            return self.getProfileFromTaskOrNode(node, 'compute')
-                                .then(function (render) {
-                                    return(render);
+                return self.getNode(macAddresses, options)
+                    .then(function (node) {
+                        return self.getProfileFromTaskOrNode(node, 'compute')
+                            .then(function (render) {
+                                return _.defaults(render, {
+                                    ignoreLookup: res.locals.macAddress ? true : false
                                 });
-                        });
-                } else {
-                    return { profile: 'redirect.ipxe', ignoreLookup: true };
-                }
-            })
-            .catch(function (err) {
-                if (!err.status) {
-                    throw new Errors.InternalServerError(err.message);
-                } else {
-                    throw err;
-                }
-            });
+                            });
+                    });
+            } else {
+                return { profile: 'redirect.ipxe', ignoreLookup: true };
+            }
+        })
+        .catch(function (err) {
+            if (!err.status) {
+                throw new Errors.InternalServerError(err.message);
+            } else {
+                throw err;
+            }
+        });
     };
 
     ProfileApiService.prototype.getProfilesSwitchVendor = function(

--- a/lib/services/swagger-api-service.js
+++ b/lib/services/swagger-api-service.js
@@ -345,7 +345,7 @@ function swaggerFactory(
                     ipaddress: res.locals.ipAddress,
                     netmask: config.get('dhcpSubnetMask', '255.255.255.0'),
                     gateway: config.get('dhcpGateway', '10.1.1.1'),
-                    macaddress: macAddress,
+                    macaddress: res.locals.macAddress || macAddress,
                     sku: env.get('config', {}, [ scope[0] ]),
                     env: env.get('config', {}, scope),
                     // Build structure that mimics the task renderContext

--- a/spec/lib/services/profile-api-service-spec.js
+++ b/spec/lib/services/profile-api-service-spec.js
@@ -78,77 +78,77 @@ describe("Http.Services.Api.Profiles", function () {
             });
     });
 
+    describe("getMacAddressInRequest", function() {
+        var query;
+        var requestIp;
+        beforeEach(function() {
+            query = {
+                macs : ['mac1', 'mac2'],
+                ips : ['ip1', 'ip2']
+            };
+            requestIp = 'ip1';
+        });
+
+        it("should get undefined when no macs is provided", function() {
+            query.macs = undefined;
+            return profileApiService.getMacAddressInRequest(query, requestIp)
+            .then(function(macAddress) {
+                expect(macAddress).to.be.equal(undefined);
+            });
+        });
+
+        it("should get undefined when no ips is provided", function() {
+            query.ips = undefined;
+            return profileApiService.getMacAddressInRequest(query, requestIp)
+            .then(function(macAddress) {
+                expect(macAddress).to.be.equal(undefined);
+            });
+        });
+
+        it("should get undefined when requestIp isn't in query ", function() {
+            requestIp = "noExistIP";
+            return profileApiService.getMacAddressInRequest(query, requestIp)
+            .then(function(macAddress) {
+                expect(macAddress).to.be.equal(undefined);
+            });
+        });
+
+        it("should get undefined when found macAddress is empty", function() {
+            query.macs = ['', 'ip2'];
+            return profileApiService.getMacAddressInRequest(query, requestIp)
+            .then(function(macAddress) {
+                expect(macAddress).to.be.equal(undefined);
+            });
+        });
+
+        it("should get undefined when found index in ips is out of range in macs", function() {
+            query.macs = ['mac1'];
+            requestIp = "ip2";
+            return profileApiService.getMacAddressInRequest(query, requestIp)
+            .then(function(macAddress) {
+                expect(macAddress).to.be.equal(undefined);
+            });
+        });
+
+        it("should get correct macAddress in request", function() {
+            return profileApiService.getMacAddressInRequest(query, requestIp)
+            .then(function(macAddress) {
+                expect(macAddress).to.be.equal('mac1');
+            });
+        });
+    });
+
     describe("setLookup", function () {
-        var proxy = '12.1.1.1';
-
-        var res = {
-            locals: {
-                ipAddress: 'ip1'
-            }
-        };
-
-        var profileReq = {
-            query: {
-                'ips': ['ip1', 'ip2'],
-                'macs': ['mac1', 'mac2']
-            },
-            get: function (header) {
-                if (header === Constants.HttpHeaders.ApiProxyIp) {
-                    return proxy;
-                }
-            }
-        };
-
-        var profileReq1 = {
-            query: {
-                'ips': ['', ''],
-                'macs': ['mac1', 'mac2']
-            },
-            get: function (header) {
-                if (header === Constants.HttpHeaders.ApiProxyIp) {
-                    return proxy;
-                }
-            }
-        };
-
-        it("setLookup should add IP lookup entry and proxy", function () {
+        it("should add IP lookup entry and proxy", function() {
             this.sandbox.stub(lookupService, 'setIpAddress').resolves();
             this.sandbox.stub(waterline.lookups, 'upsertProxyToMacAddress').resolves();
-            return profileApiService.setLookup(profileReq, res)
-                .then(function () {
-                    expect(lookupService.setIpAddress).to.be.calledWithExactly('ip1', 'mac1');
-                    expect(waterline.lookups.upsertProxyToMacAddress).to.be.calledOnce;
-                });
+            return profileApiService.setLookup('ip', 'mac', 'proxyIp', 'proxyPort')
+            .then(function() {
+                expect(lookupService.setIpAddress).to.be.calledWithExactly('ip', 'mac');
+                expect(waterline.lookups.upsertProxyToMacAddress)
+                    .to.be.calledWithExactly('http://proxyIp:proxyPort', 'mac');
+            });
         });
-
-        it("setLookup does not lookup node on missing required query string", function () {
-            this.sandbox.stub(lookupService, 'setIpAddress').resolves();
-            this.sandbox.stub(waterline.lookups, 'upsertProxyToMacAddress').resolves();
-            return profileApiService.setLookup({query: {macs: 'macs'}}, res)
-                .then(function () {
-                    expect(lookupService.setIpAddress).to.not.be.called;
-                    expect(waterline.lookups.upsertProxyToMacAddress).to.not.be.called;
-                });
-        });
-
-        it("setLookup should set request IP and MAC lookup for query macs and ips", function () {
-            this.sandbox.stub(lookupService, 'setIpAddress').resolves();
-
-            return profileApiService.setLookup(profileReq, res)
-                .then(function () {
-                    expect(lookupService.setIpAddress).to.be.calledWithExactly('ip1', 'mac1');
-                });
-        });
-
-        it("setLookup should not set lookup if IP is null in query", function () {
-            this.sandbox.stub(lookupService, 'setIpAddress').resolves();
-
-            return profileApiService.setLookup(profileReq1, res)
-                .then(function () {
-                    expect(lookupService.setIpAddress).to.not.be.called;
-                });
-        });
-
     });
 
     describe("getNode", function () {
@@ -456,15 +456,30 @@ describe("Http.Services.Api.Profiles", function () {
     describe("getProfiles", function () {
 
         it("getProfiles passes", function () {
-            var query = {};
-            var res = {};
-            var req = {query: {mac: ["XX:XX:XX:XX"]}};
+            var query = {mac: ["XX:XX:XX:XX"]};
+            var res = {
+                locals: {
+                    ipAddress: 'ip1'
+                }
+            };
+            var req = {
+                get: function(header) {
+                    switch(header) {
+                        case Constants.HttpHeaders.ApiProxyIp:
+                            return '1.2.3.4';
+                        case Constants.HttpHeaders.ApiProxyPort:
+                            return '80';
+                    }
+                }
+            };
             var node = {
                 id: "1234",
                 discovered: sinon.stub().resolves(false),
                 type: 'compute'
             };
 
+            this.sandbox.stub(profileApiService, 'getMacAddressInRequest').resolves('mac1');
+            this.sandbox.stub(profileApiService, 'setLookup').resolves();
             this.sandbox.stub(waterline.nodes, 'findByIdentifier').resolves(node);
             this.sandbox.stub(taskProtocol, 'activeTaskExists').resolves();
             this.sandbox.stub(workflowApiService, 'findActiveGraphForTarget').resolves(undefined);


### PR DESCRIPTION
Fix https://rackhd.atlassian.net/browse/RAC-5768
The solution is remove lookup for macAddress when call /profiles?macs&&ips.

This is a copy of https://github.com/RackHD/on-http/pull/764

@RackHD/corecommitters 