### PR TITLE
Add ESXi installer option for clearing disk partitions

### DIFF
--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -1,9 +1,19 @@
 accepteula
-<% if (installDisk === "firstdisk") { %>
+<% if (typeof clearDisk === 'undefined') { %>
+<%   clearDisk = installDisk %>
+<% } %>
+
+<% if (clearDisk === 'firstdisk') { %>
   clearpart --firstdisk --overwritevmfs
+<% } else if (clearDisk === 'alldrives') { %>
+  clearpart --alldrives --overwritevmfs
+<% } else { %>
+  clearpart --drives=<%=clearDisk%> --overwritevmfs
+<% } %>
+
+<% if (installDisk === "firstdisk") { %>
   install --firstdisk --overwritevmfs
 <% } else { %>
-  clearpart --drives=<%=installDisk%> --overwritevmfs
   install --disk=<%=installDisk%> --overwritevmfs
 <% } %>
 rootpw <%=rootPlainPassword%>


### PR DESCRIPTION
Add `clearDisk` option to Graph.InstallESXi to allow better control
over the `clearpart` command which is used to clear disk partition
tables during OS install. Valid `clearDisk` values are:

- `null` or unspecified: only clear the partition table on the disk
  the OS is being installed to. This is the same behavior as prior to
  this change.

- `alldrives`: clear the partition table on all drives.

- or a disk path that the OS can recognize.

depends on: https://github.com/RackHD/on-tasks/pull/532