### PR TITLE
[RAC-6339] iPDU firmware update workflow define.

### DIFF
--- a/lib/graphs/examples/iPDU-firmware-update-by-sftp-graph.js
+++ b/lib/graphs/examples/iPDU-firmware-update-by-sftp-graph.js
@@ -1,0 +1,24 @@
+//Copyright © 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+"use strict";
+
+module.exports = {
+  friendlyName: "iPDU firmware update by Sftp",
+  injectableName: "Graph.FirmwareUpdateIPDU",
+  tasks: [
+     {
+            label: 'sftp-upload-firmware',
+            taskDefinition: {
+                injectableName: "Task.SftpFile",
+                friendlyName: "sftp upload firmware of iPDU",
+                implementsTask: "Task.Base.Sftp",
+                options: {
+                    isPDU: "true",
+                    fileSource: null,
+                    fileDestination: null
+                },
+                properties: {}
+            }
+    }
+  ]
+};

--- a/spec/lib/graphs/iPDU-firmware-update-by-sftp-graph-spec.js
+++ b/spec/lib/graphs/iPDU-firmware-update-by-sftp-graph-spec.js
@@ -1,0 +1,19 @@
+//Copyright © 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+/* jshint node:true */
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-graph-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require(
+            '/lib/graphs/examples/iPDU-firmware-update-by-sftp-graph.js'
+        );
+    });
+
+    describe('graph', function () {
+        base.examples();
+    });
+
+});


### PR DESCRIPTION
## iPDU:  implement the Firmware Update coding
In order to support the switch iPDU of ServerTech.  We use the 'CWG-16H2C454' model PDU to test.

The final solution is "SFTP Client put". RackHD provide a workflow to update iPDU firmware, named 'Graph.SftpOperation'.

- Relate PR : [on-tasks-536](https://github.com/RackHD/on-tasks/pull/536)

We can add a firmware update workflow by command: 

```
curl -X POST -H 'Content-Type: application/json' localhost:8080/api/2.0/nodes/{nodeID}/workflows -d '{
    "name": "Graph.SftpOperation",
    "options": {
        "defaults": {
             "isPDU": "true",
             "fileSource": "{localFile}",
             "fileDestination": "{remoteFile}"
        }
      
    }
} ' |jq '.' | grep 'instanceId'
```


@panpan0000 @anhou @pengz1 