### PR TITLE
Remove obsolete parameter after WSMAN control job refine

### DIFF
--- a/lib/graphs/dell-wsman-update-firmware-graph.js
+++ b/lib/graphs/dell-wsman-update-firmware-graph.js
@@ -5,13 +5,7 @@
 module.exports = {
     friendlyName: 'Dell wsman Update Firmware Graph',
     injectableName: 'Graph.Dell.Wsman.Update.Firmware',
-    options: {
-        defaults: {
-            serverUsername: null,
-            serverPassword: null,
-            serverFilePath: null
-        }
-    },
+    options: {},
     tasks: [
         {
             label: 'dell-wsman-update-firmware',


### PR DESCRIPTION
Background

The original WSMAN based job is out of date after SMI service updated its input parameters. And also it is lack of unit test and option schema check. Currently we refine all WSMAN implementation and aimed to integrate SMI service with RackHD and replace the RACADM. We refined the WSMAN work job arch. Now it use the new common WSMAN base job as base classs and WSMAN tool as util to send out request to SMI service. The parameters used in old wsman taskgraph are obsolete now.

Detail

Remove obsolete parameters in firmware update graph.

Test Result

Tested pass on Dell R730 server.

Review: @yaolingling @anhou @lanchongyizu @AlaricChan