### PR TITLE
[RAC-6433] Refine workflow parameters for WSMAN based config BIOS

### DIFF
--- a/lib/graphs/dell-wsman-configure-bios-graph.js
+++ b/lib/graphs/dell-wsman-configure-bios-graph.js
@@ -7,14 +7,12 @@ module.exports = {
     injectableName: 'Graph.Dell.Wsman.ConfigureBios',
     options: {
         defaults: {
-            attributes: null,
-            biosBootSequenceOrder: null,
-            hddSequenceOrder: null,
-            enableBootDevices: null,
-            disableBootDevices: null,
-            rebootJobType: null,
-            scheduledStartTime: null,
-            untilTime: null
+            attributes: [''],
+            biosBootSequenceOrder: [''],
+            hddSequenceOrder: [''],
+            enableBootDevices: [''],
+            disableBootDevices: [''],
+            rebootJobType: 1
         }
     },
     tasks: [

--- a/lib/graphs/dell-wsman-configure-bios-graph.js
+++ b/lib/graphs/dell-wsman-configure-bios-graph.js
@@ -7,7 +7,7 @@ module.exports = {
     injectableName: 'Graph.Dell.Wsman.ConfigureBios',
     options: {
         defaults: {
-            attributes: [''],
+            attributes: null,
             biosBootSequenceOrder: [''],
             hddSequenceOrder: [''],
             enableBootDevices: [''],


### PR DESCRIPTION
**Background**
Based on the preceding work (  RAC-6265 DONE  ),  the configBios workflow parameters need to be refined. The "scheduledStartTime" and "utilTime" parameter will be hiden for users.  The schema will be changed.

depends on:https://github.com/RackHD/on-tasks/pull/547

**Reviewers**
@nortonluo @lanchongyizu @AlaricChan @anhou 
