### PR TITLE
Unit test fix for mocha update

### DIFF
--- a/spec/lib/services/templates-api-service-spec.js
+++ b/spec/lib/services/templates-api-service-spec.js
@@ -99,7 +99,7 @@ describe('Http.Api.Templates', function () {
             };
 
             getNodeByIdentifierStub.resolves();
-            return templatesApiService.templatesGetByName(req, res)
+            templatesApiService.templatesGetByName(req, res)
                 .then(function () {
                     throw new Error('Should throw errors');
                 })
@@ -118,7 +118,7 @@ describe('Http.Api.Templates', function () {
 
         it('should throw no node found error', function (done) {
             getNodeByIdentifierStub.resolves();
-            return templatesApiService.templatesGetByName(req, res)
+            templatesApiService.templatesGetByName(req, res)
                 .then(function () {
                     throw new Error('Should throw errors');
                 })
@@ -140,7 +140,7 @@ describe('Http.Api.Templates', function () {
             };
             getNodeByIdentifierStub.resolves({id: nodeId});
             findActiveGraphForTargetStub.resolves();
-            return templatesApiService.templatesGetByName(req, res)
+            templatesApiService.templatesGetByName(req, res)
                 .then(function () {
                     throw new Error('Should throw errors');
                 })

--- a/spec/lib/task-runner-spec.js
+++ b/spec/lib/task-runner-spec.js
@@ -96,7 +96,7 @@ describe("Task Runner", function() {
         });
 
         it('should mark itself running', function(done) {
-            return runner.start()
+            runner.start()
             .then(asyncAssertWrapper(done, function() {
                 expect(runner.isRunning()).to.equal(true);
             }));
@@ -104,14 +104,14 @@ describe("Task Runner", function() {
 
         it('should initialize its pipelines', function(done) {
             this.sandbox.stub(store, 'heartbeatTasksForRunner');
-            return runner.start()
+            runner.start()
             .then(asyncAssertWrapper(done, function() {
                 expect(runner.initializePipeline).to.have.been.calledOnce;
             }));
         });
 
         it('should subscribe to a task messenger', function(done) {
-            return runner.start()
+            runner.start()
             .then(asyncAssertWrapper(done, function() {
                 expect(runner.subscribeRunTask).to.have.been.calledOnce;
             }));

--- a/spec/lib/task-scheduler-spec.js
+++ b/spec/lib/task-scheduler-spec.js
@@ -381,7 +381,7 @@ describe('Task Scheduler', function() {
                 var evaluateGraphStream = new Rx.Subject();
                 observable = taskScheduler.createTasksToScheduleSubscription(evaluateGraphStream);
 
-                return taskScheduler.stop()
+                taskScheduler.stop()
                 .then(function() {
                     streamCompletedWrapper(observable, done, function() {
                         expect(store.findReadyTasks).to.not.have.been.called;
@@ -424,10 +424,10 @@ describe('Task Scheduler', function() {
                     expect(taskScheduler.handleScheduleTaskEvent).to.have.been.calledWith(task);
                 });
             });
-            
+
             it('should validate the return result of getGraphNameAndTaskNameFromDB', function(){
                 var task_data = {
-                    "domain":"default", 
+                    "domain":"default",
                     "task":{
                         "instanceId":"task.instanceId",
                         "injectableName":"task.injectableName"
@@ -445,12 +445,12 @@ describe('Task Scheduler', function() {
                    expect(res.graphId).to.equal(task_data.graphId);
                    expect(res.graphName).to.equal(task_data.context.graphName);
 		});
-                
+
             });
-           
+
             it('should handle handleScheduleTaskEvent errors', function(done) {
                 var testError = new Error('test handleScheduleTaskEvent error');
-            
+
                 taskScheduler.findReadyTasks.resolves({ tasks: [{}] });
                 taskScheduler.handleScheduleTaskEvent.restore();
                 taskScheduler.publishScheduleTaskEvent.rejects(testError);
@@ -529,7 +529,7 @@ describe('Task Scheduler', function() {
             this.sandbox.stub(taskScheduler, 'updateTaskDependencies');
             taskScheduler.subscriptions = [];
 
-            return taskScheduler.stop()
+            taskScheduler.stop()
             .then(function() {
                 streamCompletedWrapper(observable, done, function() {
                     expect(taskScheduler.updateTaskDependencies).to.not.have.been.called;
@@ -622,7 +622,7 @@ describe('Task Scheduler', function() {
             observable = taskScheduler.createCheckGraphFinishedSubscription(
                 checkGraphFinishedStream);
 
-            return taskScheduler.stop()
+            taskScheduler.stop()
             .then(function() {
                 streamCompletedWrapper(observable, done, function() {
                     expect(taskScheduler.checkGraphSucceeded).to.not.have.been.called;


### PR DESCRIPTION
RAC:  [https://rackhd.atlassian.net/browse/RAC-5743](https://rackhd.atlassian.net/browse/RAC-5743)
----
Paired with @PengTian0 

Using both `return promise` and `done()` in async unit test case will cause following error:
`Resolution method is overspecified. Specify a callback *or* return a Promise; not both.`

According to Mocha's [official site](http://mochajs.org/):
`In Mocha v3.0.0 and newer, returning a Promise and calling done() will result in an exception`

**Solution**
----
Only call done() instead of return a promise in all async unit test cases.


@PengTian0 @pengz1 @anhou @iceiilin @bbcyyb 