### PR TITLE
Fix mocha not exit bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "istanbul": "^0.3.5",
     "jsdoc": "^3.3.0-alpha13",
     "jshint": "^2.5.11",
-    "mocha": "^2.1.0",
+    "mocha": "^4.0.1",
     "mockery": "^2.0.0",
     "sinon": "^1.12.2",
     "sinon-as-promised": "^2.0.3",

--- a/spec/lib/task-scheduler-spec.js
+++ b/spec/lib/task-scheduler-spec.js
@@ -198,7 +198,9 @@ describe('Task Scheduler', function() {
         });
 
         it('start', function() {
-            var stub = sinon.stub();
+            var stub = {
+                dispose: sinon.stub().resolves()
+            };
             this.sandbox.stub(taskScheduler, 'subscribeRunTaskGraph').resolves(stub);
             this.sandbox.stub(taskScheduler, 'subscribeTaskFinished').resolves(stub);
             this.sandbox.stub(taskScheduler, 'subscribeCancelGraph').resolves(stub);
@@ -209,6 +211,8 @@ describe('Task Scheduler', function() {
                 expect(LeaseExpirationPoller.create).to.have.been.calledOnce;
                 expect(taskScheduler.leasePoller.start).to.have.been.calledOnce;
                 expect(taskScheduler.subscriptions).to.deep.equal([stub, stub, stub]);
+            }).then(function() {
+                taskScheduler.stop(); // Stop taskScheduler or mocha will not exit properly
             });
         });
 


### PR DESCRIPTION
**Background**
----
With mocha(>=3.0) unit test can not exit properly if any services or threads like socket are not closed.
**SEE**.[https://github.com/mochajs/mocha/issues/3044](https://github.com/mochajs/mocha/issues/3044)

[https://rackhd.atlassian.net/browse/RAC-5743](https://rackhd.atlassian.net/browse/RAC-5743)

**Detail**
----
In `task-scheduler-spec.js` taskScheduler service started but not stoped, this cause mocha hanging there, to fix this, `taskScheduler.stop()` needed.


@iceiilin @anhou @pengz1 @bbcyyb @PengTian0 