### PR TITLE
Fix graph parameter

### DIFF
--- a/lib/graphs/dell-wsman-update-firmware-graph.js
+++ b/lib/graphs/dell-wsman-update-firmware-graph.js
@@ -5,7 +5,11 @@
 module.exports = {
     friendlyName: 'Dell wsman Update Firmware Graph',
     injectableName: 'Graph.Dell.Wsman.Update.Firmware',
-    options: {},
+    options: {
+        shareFolderAddress: null,
+        shareFolderType: null,
+        shareFolderName: null
+    },
     tasks: [
         {
             label: 'dell-wsman-update-firmware',


### PR DESCRIPTION
## Background
This PR will fix the npm test fail in on-taskgraph. The unit test in on-taskgraph will check the paramters in schema. If the parameter do not have default value, it will throw an error. Recently the schema of wsman firmware update is newly updated, and will result unit test fail.

## Details
Set all the parameters required by schema in on-tasks default value as null.