### PR TITLE
RAC-6480 Refine get system config catalog graph parameters

### DIFF
--- a/lib/graphs/dell-wsman-get-systemcomponents-catalog-graph.js
+++ b/lib/graphs/dell-wsman-get-systemcomponents-catalog-graph.js
@@ -7,15 +7,8 @@ module.exports = {
     injectableName: 'Graph.Dell.Wsman.GetSystemComponentsCatalog',
     options: {
         defaults: {
-            serverIP: null,
-            serverUsername: null,
-            serverPassword: null,
-            shareType: null,
-            shareAddress: null,
-            shareName: null,
-            fileName: null,
-            shutdownType: null,
-            componentNames: null
+            shutdownType: 0,
+            componentNames: [],
         }
     },
     tasks: [


### PR DESCRIPTION
## Background

The original get system config components task is not working. it used share folder to handle .xml exchange file but it doesn't accept share folder username &password.
It only do catalog create. When there is already catalogs in db, it will get problem.
Also latest data format update in SMI service response make the result data incorrect.

## Action

Add share folder setting parameters. It should be still compatible with original call method.
Change catalog create method. Only create if there is no such record in db. If found similar on, it only do update.
Fixed the json format transfer bug.
Add task schema
Add unit test for all the jobs.

@lanchongyizu @yaolingling @AlaricChan @anhou @leoyjchang

It depends on:RackHD/on-tasks#564