### PR TITLE
[RAC-6385] Fix ubuntu16.04 support

### DIFF
--- a/data/templates/install-ubuntu/ubuntu-preseed
+++ b/data/templates/install-ubuntu/ubuntu-preseed
@@ -1,3 +1,4 @@
+### Copyright 2015-2017, Dell EMC, Inc.
 #### Contents of the preconfiguration file (for squeeze)
 ### Localization
 d-i debian-installer/locale string en_US.UTF-8
@@ -224,12 +225,13 @@ in-target vconfig add ip.device <%=vid%>; \
         <%_ } _%>
     <%_ } _%>
 <%_ }); _%>
-wget http://<%=server%>:<%=port%>/api/current/templates/ubuntu-interfaces?nodeId=<%=nodeId%> -O /etc/network/interfaces; \
+in-target wget http://<%=server%>:<%=port%>/api/current/templates/ubuntu-interfaces?nodeId=<%=nodeId%> -O /etc/network/interfaces; \
 <%_ } _%>
 in-target wget http://<%=server%>:<%=port%>/api/current/templates/post-install-ubuntu.sh?nodeId=<%=nodeId%> -O ./post-install.sh; \
 in-target chmod +x ./post-install.sh; \
 in-target ./post-install.sh; \
 in-target wget http://<%=server%>:<%=port%>/api/current/templates/ubuntu-sources?nodeId=<%=nodeId%> -O /etc/apt/sources.list; \
-in-target wget http://<%=server%>:<%=port%>/api/current/templates/<%=rackhdCallbackScript%>?nodeId=<%=nodeId%> -O /etc/rc2.d/S99callback; \
-in-target chmod +x /etc/rc2.d/S99callback; \
+in-target wget http://<%=server%>:<%=port%>/api/current/templates/<%=rackhdCallbackScript%>?nodeId=<%=nodeId%> -O /etc/init.d/RackHDCallback; \
+in-target chmod +x /etc/init.d/RackHDCallback; \
+in-target update-rc.d RackHDCallback defaults; \
 in-target curl -X POST -H 'Content-Type:application/json' http://<%=server%>:<%=port%>/api/current/notification?nodeId=<%=nodeId%>

--- a/data/templates/install-ubuntu/ubuntu.rackhdcallback
+++ b/data/templates/install-ubuntu/ubuntu.rackhdcallback
@@ -1,6 +1,19 @@
 #! /bin/bash
+# Copyright 2015-2017, Dell EMC, Inc.
+
+#### BEGIN INIT INFO
+# Provides:          RackHDCallback
+# Required-Start:    $all
+# Required-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: RackHD callback
+# Description:       RackHD callback to give RackHD feedback that reboot is done.
+##### END INIT INFO
 
 echo "Attempting to call back to RackHD Ubuntu installer"
 wget --retry-connrefused --waitretry=1 -t 300 --post-data '{"nodeId":"<%=nodeId%>"}' --header='Content-Type:application/json' http://<%=server%>:<%=port%>/api/current/notification
-# Delete file
-rm $0
+
+# remove file
+rm /etc/init.d/RackHDCallback
+update-rc.d RackHDCallback remove


### PR DESCRIPTION
****Background:**** 
----
Workflow cannot finish after successfully installed ubuntu16.04, this is because callback script in 16.04 cannot be executed during the init boot.

Detail:
----
Ubuntu 16.04 uses _**systemd**_ to start the boot scripts not _**init**_ in 14.04, but scripts in **_/init.d_** can still work in 16.04 because 16.04 uses _**systemd-sysv-generator**_ to generate services for each script in /init.d(purpose of backward compatibility). And there is no runlevel concept in 16.04, boot facilities should run in parallel, if sequential is required, use  **_LSB comment header_** in scripts.

For more detail about LSB please see [https://wiki.debian.org/LSBInitScripts](https://wiki.debian.org/LSBInitScripts)

@pengz1 @anhou @PengTian0 @Ara4Sh
