### PR TITLE
Adding redfish node for chassis/system combo

### DIFF
--- a/lib/graphs/run-rest-command-graph.js
+++ b/lib/graphs/run-rest-command-graph.js
@@ -1,0 +1,26 @@
+// Copyright 2017, EMC, Inc.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Run rest command',
+    injectableName: 'Graph.Run.Rest.Command',
+    options: {
+        defaults: {
+            url: null,
+            credential: null,
+            method: null,
+            headers: null,
+            data: null,
+            verifySSL: null,
+            recvTimeoutMs: null
+       }
+    },
+    tasks: [
+        {
+            label: 'run-rest-command',
+            taskName: 'Task.run.rest.command'
+        }
+    ]
+};
+


### PR DESCRIPTION
Adding graph to run REST commands on external hosts, currently for used with redfish discovery.
************
Part of Changes in on-core, on-http, on-tasks, on-taskgraph
The combination of these changes is to fully implement redfish device discovery. This includes the fillowing items:
1) The implementation of unique device identifiers in place of the RackHD GUID identifers.
    a) These ids provide the user the ability to know which node they are looking at. This is usefull for
       aggregation.
    b) All RackHD Redfish calls can use either the new id or the original RackHD GUID. The RackHD api still can
       only use the GUID.
    c) Currently this id is made with a combination of the serial number and sku from the redfish discovery.
2) Creation of redfish and redfishManager node types.
    a) redfish nodes are combination of systems and chassis in one node. This is because some redfish implementations
       report system and chassis as one object.
    b) redfishManagers are a node object to store information about the managers discovered durring redfish discovery.
    c) Maintains support with /Chassis /Systems and /Managers Redfish calls.
3) Dynamic modification of redfish catalogs.
    a) injection of the unique device id into the discovered redfish catalogs.
    b) catalog names and id use the unique device id.
    c) stored in only the relavent node with the source as the odata.id of the call that got the info.
       ie. /Systems/{identifier}/...
4) Implemented support for redfish discovered devices in the redfish API (GET, PATCH, and POST).
    a) GETs returned the stored catalogs from discovery
    b) PUTs and POSTs start a wrokflow that does the Redfish call on the discovered device with the provide payload
5) Modified spec test to support redfish devices.
    a) Changed from nodeApi stubbing to waterline stubbing in system and chassis spec tests.
6) Implementation of general purpose REST API workflow.
    a) Currently used for doing redfish calls but can be run with any REST calls.
7) RackHD Redfish API only works for calls which the device '@odata.id's match the RackHD Redfish implementation
    a) not all devices follow this implementation due to the opaque nature of the Redfish odata links
    b) To support all would require work to interpret all data during discovery and dynamically store it.
Reddish Discovery allows for the aggregation of Redfish complaint devices. The discovery creates node objects for compute, enclosure, redfish, and redfishManager nodes. The redfish nodes are a combination of a system and chassis and the redfishManager is for storing the manager objects discovered.
