### PR TITLE
Adds support for Netplan

### DIFF
--- a/data/templates/install-ubuntu/ubuntu-netplan-interfaces
+++ b/data/templates/install-ubuntu/ubuntu-netplan-interfaces
@@ -1,0 +1,90 @@
+<%_ if (typeof networkDevices !== 'undefined' && networkDevices.length > 0) { _%>
+<%_ var vlans={} _%>
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+  <%_ networkDevices.forEach(function(n) { _%>
+    <%_ var addresses=[] _%>
+    <%_ var gw4 _%>
+    <%_ var gw6 _%>
+    <%_ for (p in n) { _%>
+        <%_ ip = n[p]; _%>
+        <%_ if (['ipv4', 'ipv6'].indexOf(p) === -1 || undefined == ip) continue; _%>
+        <%_ if (undefined !== ip.vlanIds) { _%>
+            <%_ ip.vlanIds.forEach(function(vid) { _%>
+                <%_ var vl = n.device + "." + vid _%>
+                <%_ if (!(vl in vlans)) vlans[vl] = {} _%>
+                <%_ var vlan = vlans[vl] _%>
+                <%_ vlan["device"] = n.device _%>
+                <%_ vlan["id"] = vid _%>
+                <%_ if (!("addr" in vlan)) vlan["addr"] = [] _%>
+                <%_ vlan["addr"].push(ip.ipAddr+"/"+ip.netmask) _%>
+                <%_ if ('ipv4' === p) { _%>
+                   <%_ vlan["gw4"] = ip.gateway _%>
+                <%_ } _%>
+                <%_ if ('ipv6' === p) { _%>
+                    <%_ vlan["gw6"] = ip.gateway _%>
+                <%_ } _%>
+
+            <%_ }); _%>
+        <%_ } else { _%>
+            <%_ addresses.push(ip.ipAddr+"/"+ip.netmask) _%>
+            <%_ if ('ipv4' === p) { _%>
+               <%_ gw4 = ip.gateway _%>
+            <%_ } _%>
+            <%_ if ('ipv6' === p) { _%>
+               <%_ gw6 = ip.gateway _%>
+            <%_ } _%>
+        <%_ } _%>
+    <%_ } _%>
+    <%=n.device%>:
+      dhcp4: no
+      dhcp6: no
+        <%_ if (addresses.length > 0) { _%>
+      addresses:
+            <%_ addresses.forEach(function(a) { _%>
+        - <%= a %>
+            <%_ }); _%>
+            <%_ if (typeof gw4 !== 'undefined') { _%>
+      gateway4: <%= gw4 %> <%_ } %>
+            <%_ if (typeof gw6 !== 'undefined') { _%>
+      gateway6: <%= gw6 %> <%_ } %>
+<% if (typeof dnsServers !== 'undefined' && dnsServers.length > 0) { -%>
+      nameservers:
+        addresses: [<%=dnsServers.join(',')%>]
+<% } -%>
+        <%_ } _%>
+
+  <%_ }); _%>
+
+  <%_ if (typeof vlans !== 'undefined' && Object.keys(vlans).length > 0) { _%>
+  vlans:
+    <%_ for (p in vlans) { _%>
+    <%= p %>:
+    <%_ vl = vlans[p] _%>
+      dhcp4: no
+      dhcp6: no
+      id: <%= vl["id"] %>
+      link: <%= vl["device"] %>
+      <%_ addresses = vl["addr"] _%>
+      <%_ if (addresses.length > 0) { _%>
+      addresses:
+            <%_ addresses.forEach(function(a) { _%>
+        - <%= a %>
+            <%_ }); _%>
+            <%_ gw4 = vl["gw4"] _%>
+            <%_ if (typeof gw4 !== 'undefined') { _%>
+      gateway4: <%= gw4 %> <%_ } %>
+            <%_ gw6 = vl["gw6"] _%>
+            <%_ if (typeof gw6 !== 'undefined') { _%>
+      gateway6: <%= gw6 %> <%_ } %>
+<% if (typeof dnsServers !== 'undefined' && dnsServers.length > 0) { -%>
+      nameservers:
+        addresses: [<%=dnsServers.join(',')%>]
+<% } -%>
+        <%_ } _%>
+    <%_ } _%>
+  <%_ } _%>
+
+<%_ } _%>

--- a/data/templates/install-ubuntu/ubuntu-netplan-interfaces
+++ b/data/templates/install-ubuntu/ubuntu-netplan-interfaces
@@ -19,21 +19,54 @@ network:
                 <%_ vlan["device"] = n.device _%>
                 <%_ vlan["id"] = vid _%>
                 <%_ if (!("addr" in vlan)) vlan["addr"] = [] _%>
-                <%_ vlan["addr"].push(ip.ipAddr+"/"+ip.netmask) _%>
                 <%_ if ('ipv4' === p) { _%>
-                   <%_ vlan["gw4"] = ip.gateway _%>
+                    <%_ vlan["gw4"] = ip.gateway _%>
+                    <%_ if( undefined != ip.netmask ) { _%>
+                        <%_ cidr_bits = 0 _%>
+                        <%_ ip.netmask.split('.').forEach(function(octet) { _%>
+                            <%_ cidr_bits+=((octet >>> 0).toString(2).match(/1/g)||[]).length; _%>
+                        <%_ }); _%>
+                        <%_ vlan["addr"].push(ip.ipAddr+"/"+cidr_bits) _%>
+                    <%_ } else { _%>
+                        <%_ vlan["addr"].push(ip.ipAddr+"/24") _%>
+                    <%_ } _%>
                 <%_ } _%>
                 <%_ if ('ipv6' === p) { _%>
                     <%_ vlan["gw6"] = ip.gateway _%>
+                    <%_ if( undefined != ip.netmask ) { _%>
+                        <%_ cidr_bits = 0 _%>
+                        <%_ ip.netmask.split('.').forEach(function(octet) { _%>
+                            <%_ cidr_bits+=((parseInt(octet, 16) >>> 0).toString(2).match(/1/g)||[]).length; _%>
+                        <%_ }); _%>
+                        <%_ vlan["addr"].push(ip.ipAddr+"/"+cidr_bits) _%>
+                    <%_ } else { _%>
+                        <%_ vlan["addr"].push(ip.ipAddr+"/48") _%>
+                    <%_ } _%>
                 <%_ } _%>
-
             <%_ }); _%>
         <%_ } else { _%>
-            <%_ addresses.push(ip.ipAddr+"/"+ip.netmask) _%>
             <%_ if ('ipv4' === p) { _%>
-               <%_ gw4 = ip.gateway _%>
+                <%_ if( undefined != ip.netmask ) { _%>
+                    <%_ cidr_bits = 0 _%>
+                    <%_ ip.netmask.split('.').forEach(function(octet) { _%>
+                        <%_ cidr_bits+=((octet >>> 0).toString(2).match(/1/g)||[]).length; _%>
+                    <%_ }); _%>
+                    <%_ addresses.push(ip.ipAddr+"/"+cidr_bits) _%>
+                <%_ } else { _%>
+                    <%_ addresses.push(ip.ipAddr+"/24") _%>
+                <%_ } _%>
+                <%_ gw4 = ip.gateway _%>
             <%_ } _%>
             <%_ if ('ipv6' === p) { _%>
+                <%_ if( undefined != ip.netmask ) { _%>
+                    <%_ cidr_bits = 0 _%>
+                    <%_ ip.netmask.split('.').forEach(function(octet) { _%>
+                        <%_ cidr_bits+=((parseInt(octet, 16) >>> 0).toString(2).match(/1/g)||[]).length; _%>
+                    <%_ }); _%>
+                    <%_ addresses.push(ip.ipAddr+"/"+cidr_bits) _%>
+                <%_ } else { _%>
+                    <%_ addresses.push(ip.ipAddr+"/48") _%>
+                <%_ } _%>
                <%_ gw6 = ip.gateway _%>
             <%_ } _%>
         <%_ } _%>
@@ -83,8 +116,8 @@ network:
       nameservers:
         addresses: [<%=dnsServers.join(',')%>]
 <% } -%>
+
         <%_ } _%>
     <%_ } _%>
   <%_ } _%>
-
 <%_ } _%>

--- a/data/templates/install-ubuntu/ubuntu-netplan-interfaces
+++ b/data/templates/install-ubuntu/ubuntu-netplan-interfaces
@@ -1,3 +1,4 @@
+<!-- ### Copyright 2017, Dell EMC, Inc. -->
 <%_ if (typeof networkDevices !== 'undefined' && networkDevices.length > 0) { _%>
 <%_ var vlans={} _%>
 network:

--- a/data/templates/install-ubuntu/ubuntu-preseed
+++ b/data/templates/install-ubuntu/ubuntu-preseed
@@ -225,7 +225,11 @@ in-target vconfig add ip.device <%=vid%>; \
         <%_ } _%>
     <%_ } _%>
 <%_ }); _%>
+<%_ if (typeof version !== 'undefined' && version === 'artful') { _%>
+in-target wget http://<%=server%>:<%=port%>/api/current/templates/ubuntu-netplan-interfaces?nodeId=<%=nodeId%> -O  /etc/netplan/01-netcfg.yaml; \
+<%_ } else { _%>
 in-target wget http://<%=server%>:<%=port%>/api/current/templates/ubuntu-interfaces?nodeId=<%=nodeId%> -O /etc/network/interfaces; \
+<%_ } _%>
 <%_ } _%>
 in-target wget http://<%=server%>:<%=port%>/api/current/templates/post-install-ubuntu.sh?nodeId=<%=nodeId%> -O ./post-install.sh; \
 in-target chmod +x ./post-install.sh; \

--- a/data/templates/install-ubuntu/ubuntu-preseed
+++ b/data/templates/install-ubuntu/ubuntu-preseed
@@ -205,7 +205,7 @@ in-target curl -X POST -H 'Content-Type:application/json' 'http://<%=server%>:<%
 <%_ } _%>
 
 #enable root ssh
-in-target sed -i 's/PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config; \
+in-target sed -i 's/.*PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config; \
 
 #Enable Network standards that supports VLANs
 #Load the 8021q module into the kernel


### PR DESCRIPTION
This change introduces a new template for Ubuntu 17.10's use of netplan instead of
the usual /etc/network/interfaces.  If the version is artful, the netplan yaml
is downloaded.

Signed-off-by: mbeierl <mark.beierl@dell.com>