### PR TITLE
Replace bootstrap-ubuntu with bootstrap-rancher

### DIFF
--- a/data/templates/cloud-config.yaml
+++ b/data/templates/cloud-config.yaml
@@ -6,7 +6,7 @@ write_files:
     content: |
       #!/bin/bash
       modprobe ipmi_devintf
-      wget -O /tmp/micro.tar.xz <%= file.server %>/common/discovery.docker.tar.xz
+      wget -O /tmp/micro.tar.xz <%= dockerUri %>
       while [ $(docker images | grep -c micro) == "0" ]; do
          xz -cd /tmp/micro.tar.xz | docker load
       done

--- a/data/templates/cloud-config.yaml
+++ b/data/templates/cloud-config.yaml
@@ -1,4 +1,5 @@
 #cloud-config
+# Copyright 2017, Dell EMC, Inc.
 write_files:
   - path: /etc/rc.local
     permissions: "0755"

--- a/lib/graphs/bootstrap-decommission-node-graph.js
+++ b/lib/graphs/bootstrap-decommission-node-graph.js
@@ -22,8 +22,8 @@ module.exports = {
         'remove-bmc-credentials': {
             users: null
         },
-        'bootstrap-ubuntu': {
-            overlayfsFile: 'secure.erase.overlay.cpio.gz'
+        'bootstrap-rancher': {
+            dockerFile: 'secure.erase.docker.tar.xz'
         }
     },
     tasks: [
@@ -40,8 +40,8 @@ module.exports = {
             }
         },
         {
-            label: 'bootstrap-ubuntu',
-            taskName: 'Task.Linux.Bootstrap.Ubuntu',
+            label: 'bootstrap-rancher',
+            taskName: 'Task.Linux.Bootstrap.Rancher',
             waitOn: {
                 'reboot-start': 'succeeded'
             }
@@ -50,7 +50,7 @@ module.exports = {
             label: 'catalog-megaraid',
             taskName: 'Task.Catalog.megaraid',
             waitOn: {
-                'bootstrap-ubuntu': 'finished'
+                'bootstrap-rancher': 'finished'
             },
             ignoreFailure: true
         },

--- a/lib/graphs/bootstrap-decommission-node-test-graph.js
+++ b/lib/graphs/bootstrap-decommission-node-test-graph.js
@@ -15,8 +15,8 @@ module.exports = {
                 }
             ]
         },
-	'bootstrap-ubuntu': {
-            overlayfsFile: 'secure.erase.overlay.cpio.gz'
+        'bootstrap-rancher': {
+            dockerFile: 'secure.erase.docker.tar.xz'
         },
         'fail-command' : {
             makeItFail: 'false',
@@ -37,8 +37,8 @@ module.exports = {
             }
         },
         {
-            label: 'bootstrap-ubuntu',
-            taskName: 'Task.Linux.Bootstrap.Ubuntu',
+            label: 'bootstrap-rancher',
+            taskName: 'Task.Linux.Bootstrap.Rancher',
             waitOn: {
                 'reboot-start': 'succeeded'
             }
@@ -48,7 +48,7 @@ module.exports = {
             taskName: 'Task.Linux.Commands',
             ignoreFailure: false,
             waitOn: {
-                'bootstrap-ubuntu': 'succeeded'
+                'bootstrap-rancher': 'succeeded'
             }
         },
         {

--- a/lib/graphs/bootstrap-megaraid-config-graph.js
+++ b/lib/graphs/bootstrap-megaraid-config-graph.js
@@ -7,8 +7,8 @@ module.exports = {
     friendlyName: 'Configure Megaraid Controler',
     injectableName: 'Graph.Bootstrap.Megaraid.Configure',
     options: {
-        'bootstrap-ubuntu': {
-             overlayfsFile: 'secure.erase.overlay.cpio.gz'
+        'bootstrap-rancher': {
+            dockerFile: 'secure.erase.docker.tar.xz'
         },
         'config-raid':{
             hddArr: null,
@@ -32,8 +32,8 @@ module.exports = {
             }
         },
         {
-            label: 'bootstrap-ubuntu',
-            taskName: 'Task.Linux.Bootstrap.Ubuntu',
+            label: 'bootstrap-rancher',
+            taskName: 'Task.Linux.Bootstrap.Rancher',
             waitOn: {
                 'reboot-start': 'succeeded'
             }
@@ -42,7 +42,7 @@ module.exports = {
             label: 'config-raid',
             taskName:'Task.Config.Megaraid',
             waitOn: {
-                'bootstrap-ubuntu': 'succeeded'
+                'bootstrap-rancher': 'succeeded'
             },
             ignoreFailure: true
         },

--- a/lib/graphs/create-megaraid-graph.js
+++ b/lib/graphs/create-megaraid-graph.js
@@ -5,6 +5,11 @@
 module.exports = {
     friendlyName: 'Create RAID via Storcli',
     injectableName: 'Graph.Raid.Create.MegaRAID',
+    options: {
+        "bootstrap-rancher": {
+            dockerFile: 'secure.erase.docker.tar.xz'
+        }
+    },
     tasks: [
         {
             label: 'set-boot-pxe',
@@ -19,8 +24,8 @@ module.exports = {
             }
         },
         {
-            label: 'bootstrap-ubuntu',
-            taskName: 'Task.Linux.Bootstrap.Ubuntu',
+            label: 'bootstrap-rancher',
+            taskName: 'Task.Linux.Bootstrap.Rancher',
             waitOn: {
                 'reboot': 'succeeded'
             }
@@ -29,7 +34,7 @@ module.exports = {
             label: 'create-raid',
             taskName: 'Task.Raid.Create.MegaRAID',
             waitOn: {
-                'bootstrap-ubuntu': 'succeeded'
+                'bootstrap-rancher': 'succeeded'
             }
         },
         {

--- a/lib/graphs/delete-megaraid-graph.js
+++ b/lib/graphs/delete-megaraid-graph.js
@@ -5,6 +5,11 @@
 module.exports = {
     friendlyName: 'Delete RAID via Storcli',
     injectableName: 'Graph.Raid.Delete.MegaRAID',
+    options: {
+        "bootstrap-rancher": {
+            dockerFile: 'secure.erase.docker.tar.xz'
+        }
+    },
     tasks: [
         {
             label: 'set-boot-pxe',
@@ -19,8 +24,8 @@ module.exports = {
             }
         },
         {
-            label: 'bootstrap-ubuntu',
-            taskName: 'Task.Linux.Bootstrap.Ubuntu',
+            label: 'bootstrap-rancher',
+            taskName: 'Task.Linux.Bootstrap.Rancher',
             waitOn: {
                 'reboot': 'succeeded'
             }
@@ -29,7 +34,7 @@ module.exports = {
             label: 'delete-raid',
             taskName: 'Task.Raid.Delete.MegaRAID',
             waitOn: {
-                'bootstrap-ubuntu': 'succeeded'
+                'bootstrap-rancher': 'succeeded'
             }
         },
         {

--- a/lib/graphs/dell-perccli-create-megaraid-graph.js
+++ b/lib/graphs/dell-perccli-create-megaraid-graph.js
@@ -7,8 +7,8 @@ module.exports = {
     friendlyName: 'Create RAID via perccli',
     injectableName: 'Graph.Raid.Create.Perccli',
     options: {
-        'bootstrap-ubuntu': {
-            overlayfsFile: 'secure.erase.overlay.cpio.gz'
+        'bootstrap-rancher': {
+            dockerFile: 'secure.erase.docker.tar.xz'
         },
         'config-raid':{
             hddArr: null,
@@ -32,8 +32,8 @@ module.exports = {
             }
         },
         {
-            label: 'bootstrap-ubuntu',
-            taskName: 'Task.Linux.Bootstrap.Ubuntu',
+            label: 'bootstrap-rancher',
+            taskName: 'Task.Linux.Bootstrap.Rancher',
             waitOn: {
                 'reboot': 'succeeded'
             }
@@ -42,7 +42,7 @@ module.exports = {
             label: 'config-raid',
             taskName:'Task.Config.Megaraid',
             waitOn: {
-                'bootstrap-ubuntu': 'succeeded'
+                'bootstrap-rancher': 'succeeded'
             },
             ignoreFailure: true
         },

--- a/lib/graphs/dell-perccli-megaraid-catalog-graph.js
+++ b/lib/graphs/dell-perccli-megaraid-catalog-graph.js
@@ -6,8 +6,8 @@ module.exports = {
     "friendlyName": "Dell perccli Catalog",
     "injectableName": "Graph.Dell.perccli.Catalog",
     "options": {
-        "bootstrap-ubuntu": {
-            overlayfsFile: 'secure.erase.overlay.cpio.gz'
+        "bootstrap-rancher": {
+            dockerFile: 'secure.erase.docker.tar.xz'
         }
     },
     "tasks": [
@@ -24,8 +24,8 @@ module.exports = {
             }
         },
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher",
             "waitOn": {
                 "reboot-start": "succeeded"
             }
@@ -35,7 +35,7 @@ module.exports = {
             "label": "catalog-perccli",
             "taskName": "Task.Catalog.perccli",
             "waitOn": {
-                "bootstrap-ubuntu": "succeeded"
+                "bootstrap-rancher": "succeeded"
             }
         },
         {

--- a/lib/graphs/dell-racadm-update-firmware-graph.js
+++ b/lib/graphs/dell-racadm-update-firmware-graph.js
@@ -50,8 +50,8 @@ module.exports = {
             }
         },
         {
-            label: 'bootstrap-ubuntu',
-            taskName: 'Task.Linux.Bootstrap.Ubuntu',
+            label: 'bootstrap-rancher',
+            taskName: 'Task.Linux.Bootstrap.Rancher',
             waitOn: {
                 'reboot': 'succeeded'
             }
@@ -60,7 +60,7 @@ module.exports = {
             label: 'dell-racadm-get-firmware-list-catalog',
             taskName: 'Task.Dell.Racadm.GetFirmwareListCatalog',
             waitOn: {
-                'bootstrap-ubuntu': 'succeeded'
+                'bootstrap-rancher': 'succeeded'
             }
         },
         {

--- a/lib/graphs/discovery-redfish-system-graph.js
+++ b/lib/graphs/discovery-redfish-system-graph.js
@@ -6,7 +6,7 @@ module.exports = {
     friendlyName: 'Redfish System Discovery',
     injectableName: 'Graph.Redfish.System.Discovery',
     options: {
-        'bootstrap-ubuntu': {
+        'bootstrap-rancher': {
             'triggerGroup': 'bootstrap',
             'kargs': {'acpi':'off'}
         },
@@ -32,8 +32,8 @@ module.exports = {
             }
         },
         {
-            label: 'bootstrap-ubuntu',
-            taskName: 'Task.Linux.Bootstrap.Ubuntu',
+            label: 'bootstrap-rancher',
+            taskName: 'Task.Linux.Bootstrap.Rancher',
             waitOn: {
 		        'reboot-start': 'finished'
             }

--- a/lib/graphs/flash-megaraid-controller-graph.js
+++ b/lib/graphs/flash-megaraid-controller-graph.js
@@ -10,6 +10,9 @@ module.exports = {
             file: null,
             downloadDir: '/opt/downloads'
         },
+        "bootstrap-rancher": {
+            dockerFile: 'secure.erase.docker.tar.xz'
+        },
         'flash-firmware': {
             'adapter': '0'
         }
@@ -28,8 +31,8 @@ module.exports = {
             }
         },
         {
-            label: 'bootstrap-ubuntu',
-            taskName: 'Task.Linux.Bootstrap.Ubuntu',
+            label: 'bootstrap-rancher',
+            taskName: 'Task.Linux.Bootstrap.Rancher',
             waitOn: {
                 'reboot': 'succeeded'
             }
@@ -38,7 +41,7 @@ module.exports = {
             label: 'download-firmware',
             taskName: 'Task.Linux.DownloadFiles',
             waitOn: {
-                'bootstrap-ubuntu': 'succeeded'
+                'bootstrap-rancher': 'succeeded'
             }
         },
         {

--- a/lib/graphs/flash-quanta-all-graph.js
+++ b/lib/graphs/flash-quanta-all-graph.js
@@ -9,11 +9,8 @@ module.exports = {
         defaults: {
             downloadDir: '/opt/downloads'
         },
-        'bootstrap-ubuntu': {
-            basefsFile: "base.trusty.3.13.0-32.squashfs.img",
-            overlayfsFile: 'overlayfs_quanta_t41_flash-v1.1-3.13.0-32.cpio.gz',
-            kernelFile: 'vmlinuz-3.13.0-32-generic',
-            initrdFile: 'initrd.img-3.13.0-32-generic'
+        'bootstrap-rancher': {
+            dockerFile: 'quanta.flash.docker.tar.xz'
         },
         'download-megaraid-firmware': {
             file: null
@@ -49,8 +46,8 @@ module.exports = {
             }
         },
         {
-            label: 'bootstrap-ubuntu',
-            taskName: 'Task.Linux.Bootstrap.Ubuntu',
+            label: 'bootstrap-rancher',
+            taskName: 'Task.Linux.Bootstrap.Rancher',
             waitOn: {
                 'reboot': 'succeeded'
             }
@@ -60,7 +57,7 @@ module.exports = {
             label: 'download-megaraid-firmware',
             taskName: 'Task.Linux.DownloadFiles',
             waitOn: {
-                'bootstrap-ubuntu': 'succeeded'
+                'bootstrap-rancher': 'succeeded'
             }
         },
         {

--- a/lib/graphs/flash-quanta-bios-graph.js
+++ b/lib/graphs/flash-quanta-bios-graph.js
@@ -9,11 +9,8 @@ module.exports = {
         "defaults": {
             "downloadDir": "/opt/downloads"
         },
-        "bootstrap-ubuntu": {
-            "basefsFile": "base.trusty.3.13.0-32.squashfs.img",
-            "overlayfsFile": "overlayfs_quanta_t41_flash-v1.1-3.13.0-32.cpio.gz",
-            "kernelFile": "vmlinuz-3.13.0-32-generic",
-            "initrdFile": "initrd.img-3.13.0-32-generic"
+        "bootstrap-rancher": {
+            "dockerFile": "quanta.flash.docker.tar.xz"
         },
         "download-bios-firmware": {
             "file": null
@@ -36,8 +33,8 @@ module.exports = {
             }
         },
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher",
             "waitOn": {
                 "reboot": "succeeded"
             }
@@ -46,7 +43,7 @@ module.exports = {
             "label": "download-bios-firmware",
             "taskName": "Task.Linux.DownloadFiles",
             "waitOn": {
-                "bootstrap-ubuntu": "succeeded"
+                "bootstrap-rancher": "succeeded"
             }
         },
         {

--- a/lib/graphs/flash-quanta-bmc-graph.js
+++ b/lib/graphs/flash-quanta-bmc-graph.js
@@ -9,11 +9,8 @@ module.exports = {
         "defaults": {
             "downloadDir": "/opt/downloads"
         },
-        "bootstrap-ubuntu": {
-            "basefsFile": "base.trusty.3.13.0-32.squashfs.img",
-            "overlayfsFile": "overlayfs_quanta_t41_flash-v1.1-3.13.0-32.cpio.gz",
-            "kernelFile": "vmlinuz-3.13.0-32-generic",
-            "initrdFile": "initrd.img-3.13.0-32-generic"
+        "bootstrap-rancher": {
+            "dockerFile": "quanta.flash.docker.tar.xz"
         },
         "download-bmc-firmware": {
             "file": null
@@ -36,8 +33,8 @@ module.exports = {
             }
         },
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher",
             "waitOn": {
                 "reboot": "succeeded"
             }
@@ -46,7 +43,7 @@ module.exports = {
             "label": "download-bmc-firmware",
             "taskName": "Task.Linux.DownloadFiles",
             "waitOn": {
-                "bootstrap-ubuntu": "succeeded"
+                "bootstrap-rancher": "succeeded"
             }
         },
         {

--- a/lib/graphs/flash-quanta-megaraid-graph.js
+++ b/lib/graphs/flash-quanta-megaraid-graph.js
@@ -9,9 +9,8 @@ module.exports = {
         "defaults": {
             "downloadDir": "/opt/downloads"
         },
-        "bootstrap-ubuntu": {
-            "basefsFile": "base.trusty.3.13.0-32.squashfs.img",
-            "overlayfsFile": "overlayfs_quanta_t41_flash-v1.1-3.13.0-32.cpio.gz"
+        "bootstrap-rancher": {
+            "dockerFile": "quanta.flash.docker.tar.xz"
         },
         "download-megaraid-firmware": {
             "file": null
@@ -34,8 +33,8 @@ module.exports = {
             }
         },
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher",
             "waitOn": {
                 "reboot": "succeeded"
             }
@@ -44,7 +43,7 @@ module.exports = {
             "label": "download-megaraid-firmware",
             "taskName": "Task.Linux.DownloadFiles",
             "waitOn": {
-                "bootstrap-ubuntu": "succeeded"
+                "bootstrap-rancher": "succeeded"
             }
         },
         {

--- a/lib/graphs/intel-flashupdt-catalog-graph.js
+++ b/lib/graphs/intel-flashupdt-catalog-graph.js
@@ -6,8 +6,8 @@ module.exports = {
     friendlyName: 'Intel Flashupdt Info',
     injectableName: 'Graph.Catalog.Intel.Flashupdt',
     options: {
-        'bootstrap-ubuntu': {
-            overlayfsFile: 'overlayfs_intel_flashupdt_syscfg-v1.1-3.13.0-32.cpio.gz'
+        'bootstrap-rancher': {
+            dockerFile: 'intel.flash.docker.tar.xz'
         }
     },
     tasks: [
@@ -24,8 +24,8 @@ module.exports = {
             }
         },
         {
-            label: 'bootstrap-ubuntu',
-            taskName: 'Task.Linux.Bootstrap.Ubuntu',
+            label: 'bootstrap-rancher',
+            taskName: 'Task.Linux.Bootstrap.Rancher',
             waitOn: {
                 'reboot-start': 'succeeded'
             }
@@ -34,7 +34,7 @@ module.exports = {
             label: 'catalog-flashupdt',
             taskName: 'Task.Catalog.flashupdt',
             waitOn: {
-                'bootstrap-ubuntu': 'succeeded'
+                'bootstrap-rancher': 'succeeded'
             },
             ignoreFailure: true
         },

--- a/lib/graphs/quanta-storcli-megaraid-catalog-graph.js
+++ b/lib/graphs/quanta-storcli-megaraid-catalog-graph.js
@@ -6,8 +6,8 @@ module.exports = {
     "friendlyName": "Quanta storcli Catalog",
     "injectableName": "Graph.Quanta.storcli.Catalog",
     "options": {
-        "bootstrap-ubuntu": {
-            overlayfsFile: 'secure.erase.overlay.cpio.gz'
+        "bootstrap-rancher": {
+            dockerFile: 'secure.erase.docker.tar.xz'
         }
     },
     "tasks": [
@@ -24,8 +24,8 @@ module.exports = {
             }
         },
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher",
             "waitOn": {
                 "reboot-start": "succeeded"
             }
@@ -35,7 +35,7 @@ module.exports = {
             "label": "catalog-storcli",
             "taskName": "Task.Catalog.megaraid",
             "waitOn": {
-                "bootstrap-ubuntu": "succeeded"
+                "bootstrap-rancher": "succeeded"
             }
         },
         {

--- a/lib/graphs/secure-erase-drive-graph.js
+++ b/lib/graphs/secure-erase-drive-graph.js
@@ -6,8 +6,8 @@ module.exports = {
     friendlyName: 'Secure Erase Drive',
     injectableName: 'Graph.Drive.SecureErase',
     options: {
-        'bootstrap-ubuntu': {
-            overlayfsFile: 'secure.erase.overlay.cpio.gz',
+        'bootstrap-rancher': {
+            dockerFile: 'secure.erase.docker.tar.xz',
             triggerGroup: 'secureErase'
         },
         'drive-secure-erase': {
@@ -41,8 +41,8 @@ module.exports = {
             }
         },
         {
-            label: 'bootstrap-ubuntu',
-            taskName: 'Task.Linux.Bootstrap.Ubuntu',
+            label: 'bootstrap-rancher',
+            taskName: 'Task.Linux.Bootstrap.Rancher',
             waitOn: {
                 'reboot': 'succeeded'
             }

--- a/lib/graphs/shell-command-graph.js
+++ b/lib/graphs/shell-command-graph.js
@@ -19,8 +19,8 @@ module.exports = {
             }
         },
         {
-            label: 'bootstrap-ubuntu',
-            taskName: 'Task.Linux.Bootstrap.Ubuntu',
+            label: 'bootstrap-rancher',
+            taskName: 'Task.Linux.Bootstrap.Rancher',
             waitOn: {
                 'reboot-start': 'succeeded'
             }
@@ -29,7 +29,7 @@ module.exports = {
             label: 'shell-commands',
             taskName: 'Task.Linux.Commands',
             waitOn: {
-                'bootstrap-ubuntu': 'succeeded'
+                'bootstrap-rancher': 'succeeded'
             }
         },
         {

--- a/lib/graphs/write-quanta-bios-nvram-graph.js
+++ b/lib/graphs/write-quanta-bios-nvram-graph.js
@@ -9,8 +9,8 @@ module.exports = {
         defaults: {
             file: null
         },
-        'bootstrap-ubuntu': {
-            overlayfsFile: 'overlayfs_quanta_t41_flash-v1.1-3.13.0-32.cpio.gz'
+        'bootstrap-rancher': {
+            dockerFile: 'quanta.flash.docker.tar.xz'
         }
     },
     tasks: [
@@ -27,8 +27,8 @@ module.exports = {
             }
         },
         {
-            label: 'bootstrap-ubuntu',
-            taskName: 'Task.Linux.Bootstrap.Ubuntu',
+            label: 'bootstrap-rancher',
+            taskName: 'Task.Linux.Bootstrap.Rancher',
             waitOn: {
                 'reboot': 'succeeded'
             }
@@ -38,7 +38,7 @@ module.exports = {
             label: 'download-nvram-settings',
             taskName: 'Task.Linux.DownloadFiles',
             waitOn: {
-                'bootstrap-ubuntu': 'succeeded'
+                'bootstrap-rancher': 'succeeded'
             }
         },
         // Write BIOS config settings to nvram


### PR DESCRIPTION
**Background**

Currently, we have replaced old microkernel with RancherOS, but we only use `bootstrap-rancher` to run discovery workflow. Here is to replace all other `bootstrap-ubuntu` with `bootstrap-rancher`. 
This is related with https://rackhd.atlassian.net/browse/RAC-6581

**Done**

* Replace all other `bootstrap-ubuntu` with `bootstrap-rancher`
* Replace `overlayfsFile` with `dockerFile`

depends on: https://github.com/RackHD/on-tasks/pull/577
 
@RackHD/corecommitters @keedya 