### PR TITLE
Add catalog-perccli for rancher-discovery-graph

### DIFF
--- a/lib/graphs/rancher-discovery-graph.js
+++ b/lib/graphs/rancher-discovery-graph.js
@@ -66,10 +66,18 @@ module.exports = {
             ignoreFailure: true
         },
         {
+            label: 'catalog-perccli',
+            taskName: 'Task.Catalog.perccli',
+            waitOn: {
+                'catalog-megaraid': 'finished'
+            },
+            ignoreFailure: true
+        },
+        {
             label: 'catalog-smart',
             taskName: 'Task.Catalog.smart',
             waitOn: {
-                'catalog-megaraid': 'finished'
+                'catalog-perccli': 'finished'
             },
             ignoreFailure: true
         },


### PR DESCRIPTION
**Background**

Users need to catalog raid when node discovered in a data center which has both Dell and Intel servers.
https://rackhd.atlassian.net/browse/RAC-6590

**Done**

Add catalog-perccli for rancher-discovery-graph

@RackHD/corecommitters @pengz1 