### PR TITLE
 Fix CentOS bug with minimal package image

### DIFF
--- a/data/templates/centos-ks
+++ b/data/templates/centos-ks
@@ -1,4 +1,7 @@
-# Copyright 2017, DELL, Inc.
+# Copyright © 2017-2018 Dell Inc. or its subsidiaries. All Rights Reserved.
+# For more details on CentOS/RHEL kickstart configurations, please refer to below link:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/installation_guide/sect-kickstart-syntax
+
 install
 #text
 graphical
@@ -73,7 +76,7 @@ clearpart --all --drives=<%=installDisk%>
 reboot
 
 # Package Selection
-%packages --nobase --excludedocs
+%packages --nobase --excludedocs --ignoremissing
 @core
 -*firmware
 -iscsi*
@@ -298,8 +301,9 @@ export PATH
 <% } %>
 
 # Download the service to callback to RackHD after OS installation/reboot completion
-echo "RackHD POST script wget started"
-/usr/bin/wget http://<%=server%>:<%=port%>/api/current/templates/<%=rackhdCallbackScript%>?nodeId=<%=nodeId%> -O /etc/rc.d/init.d/<%=rackhdCallbackScript%>
+echo "RackHD POST script curl started"
+/bin/curl http://<%=server%>:<%=port%>/api/current/templates/<%=rackhdCallbackScript%>?nodeId=<%=nodeId%> > /etc/rc.d/init.d/<%=rackhdCallbackScript%>
+
 echo "RackHD POST script chmod callback script"
 chmod +x /etc/rc.d/init.d/<%=rackhdCallbackScript%>
 # Enable the above service, it should auto-disable after running once

--- a/data/templates/centos.rackhdcallback
+++ b/data/templates/centos.rackhdcallback
@@ -1,4 +1,5 @@
 #! /bin/bash
+# Copyright © 2018 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # centos.rackhdcallback       callback to rackhd post installation API hook
 #
@@ -26,6 +27,7 @@
 # Nothing wrong with set -e here since we're not doing anything complex
 set -e
 echo "Attempting to call back to RackHD CentOS installer"
-wget --retry-connrefused --waitretry=1 -t 300 --post-data '{"nodeId":"<%=nodeId%>"}' --header='Content-Type:application/json' http://<%=server%>:<%=port%>/api/current/notification
+curl -X POST -H 'Content-Type:application/json'  --max-time 1000 --connect-timeout 9 --retry-delay 1 --retry 100 'http://<%=server%>:<%=port%>/api/current/notification?nodeId=<%=nodeId%>'
+
 # Only run this once to verify the OS was installed, then disable it forever
 chkconfig centos.rackhdcallback off

--- a/lib/graphs/set-bmc-credentials-graph.js
+++ b/lib/graphs/set-bmc-credentials-graph.js
@@ -1,5 +1,4 @@
-// Copyright 2016, EMC, Inc.
-
+// Copyright © 2016-2018 Dell Inc. or its subsidiaries. All Rights Reserved.
 'use strict';
 
 module.exports = {
@@ -33,7 +32,6 @@ module.exports = {
             },
             ignoreFailure: true
         },
-
         {
             label: 'catalog-bmc',
             taskName: 'Task.Catalog.bmc',


### PR DESCRIPTION
 CentOS minimal package image doesn't have wget package, this will lead
 to installation pending on requiring user confirmation and callback
 failure. To fix this:
 1. Use --ignoremissing for %packages in centos-ks.
 2. Replace all wget in centos-ks and centos callback script to curl.


@lanchongyizu @mcgG @nortonluo @HQebupt @yaolingling @AlaricChan 