### PR TITLE
Don't escape password in templates

### DIFF
--- a/data/templates/ansible-external-inventory.js
+++ b/data/templates/ansible-external-inventory.js
@@ -14,7 +14,7 @@ switch (command) {
                         'hostvars': {
                             '<%=ipaddress%>': {
                                 'ansible_ssh_user': '<%=username%>',
-                                'ansible_sudo_pass': '<%=password%>'
+                                'ansible_sudo_pass': '<%-password%>'
                             }
                         }
                     },

--- a/data/templates/autounattend_windows_2012_r2_SMC_6028U-TR4+.xml
+++ b/data/templates/autounattend_windows_2012_r2_SMC_6028U-TR4+.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- # Copyright 2016-2018, Dell EMC, Inc. -->
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <settings pass="windowsPE">
         <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -75,7 +76,7 @@
         <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <AutoLogon>
                 <Password>
-                    <Value><%=password%></Value>
+                    <Value><%-password%></Value>
                     <PlainText>true</PlainText>
                 </Password>
                 <LogonCount>2</LogonCount>
@@ -104,13 +105,13 @@
             </OOBE>
             <UserAccounts>
                 <AdministratorPassword>
-                    <Value><%=password%></Value>
+                    <Value><%-password%></Value>
                     <PlainText>true</PlainText>
                 </AdministratorPassword>
 		<LocalAccounts>
                  <LocalAccount wcm:action="add">
                     <Password>
-                      <Value><%=password%></Value>
+                      <Value><%-password%></Value>
                         <PlainText>true</PlainText>
                     </Password>
                     <Group>administrators;users</Group>

--- a/data/templates/autounattend_windows_2012_r2_unknown.xml
+++ b/data/templates/autounattend_windows_2012_r2_unknown.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- # Copyright 2016-2018, Dell EMC, Inc. -->
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <settings pass="windowsPE">
         <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -75,7 +76,7 @@
         <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <AutoLogon>
                 <Password>
-                    <Value><%=password%></Value>
+                    <Value><%-password%></Value>
                     <PlainText>true</PlainText>
                 </Password>
                 <LogonCount>2</LogonCount>
@@ -104,13 +105,13 @@
             </OOBE>
             <UserAccounts>
                 <AdministratorPassword>
-                    <Value><%=password%></Value>
+                    <Value><%-password%></Value>
                     <PlainText>true</PlainText>
                 </AdministratorPassword>
 		<LocalAccounts>
                  <LocalAccount wcm:action="add">
                     <Password>
-                      <Value><%=password%></Value>
+                      <Value><%-password%></Value>
                         <PlainText>true</PlainText>
                     </Password>
                     <Group>administrators;users</Group>

--- a/data/templates/autounattend_windows_2012_r2_vmware.xml
+++ b/data/templates/autounattend_windows_2012_r2_vmware.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- # Copyright 2016-2018, DELL EMC, Inc. -->
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <settings pass="windowsPE">
         <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -101,7 +102,7 @@
         <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
            <AutoLogon>
                 <Password>
-                    <Value><%=password%></Value>
+                    <Value><%-password%></Value>
                     <PlainText>true</PlainText>
                 </Password>
                 <LogonCount>2</LogonCount>
@@ -130,13 +131,13 @@
             </OOBE>
             <UserAccounts>
                 <AdministratorPassword>
-                    <Value><%=password%></Value>
+                    <Value><%-password%></Value>
                     <PlainText>true</PlainText>
                 </AdministratorPassword>
                 <LocalAccounts>
                  <LocalAccount wcm:action="add">
                     <Password>
-                      <Value><%=password%></Value>
+                      <Value><%-password%></Value>
                         <PlainText>true</PlainText>
                     </Password>
                     <Group>administrators;users</Group>

--- a/data/templates/centos-ks
+++ b/data/templates/centos-ks
@@ -1,4 +1,4 @@
-# Copyright 2017, DELL, Inc.
+# Copyright 2016-2018, DELL EMC, Inc.
 install
 #text
 graphical
@@ -26,15 +26,15 @@ services --enabled=NetworkManager,sshd
 authconfig --enableshadow --passalgo=sha512 --enablefingerprint
 
 #Set the root account
-rootpw --iscrypted <%=rootEncryptedPassword%>
+rootpw --iscrypted <%-rootEncryptedPassword%>
 
 #create all users
 <% if (typeof users !== 'undefined') { %>
 <% users.forEach(function(user) { %>
 <%_  if( typeof user.uid !== 'undefined' ) { _%>
-        user --name=<%=user.name%> --uid=<%=user.uid%> --iscrypted --password <%=user.encryptedPassword%>
+        user --name=<%=user.name%> --uid=<%=user.uid%> --iscrypted --password <%-user.encryptedPassword%>
 <%_  } else { _%>
-        user --name=<%=user.name%>  --iscrypted --password <%=user.encryptedPassword%>
+        user --name=<%=user.name%>  --iscrypted --password <%-user.encryptedPassword%>
 <%_ }}) _%>
 <% } %>
 

--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -1,4 +1,5 @@
 accepteula
+<!-- # Copyright 2016-2018, Dell EMC, Inc. -->
 <% if (typeof clearDisk === 'undefined') { %>
 <%   clearDisk = installDisk %>
 <% } %>
@@ -16,7 +17,7 @@ accepteula
 <% } else { %>
   install --disk=<%=installDisk%> --overwritevmfs
 <% } %>
-rootpw <%=rootPlainPassword%>
+rootpw <%-rootPlainPassword%>
 
 # Search the networkDevices and set the first device (if defined) up.
 # Use kargs if set to override the default kickstart network device
@@ -93,7 +94,7 @@ rm /vmfs/volumes/datastore1/rackhd_create_sshkeys
 <% if( typeof users !== 'undefined' ) { %>
 <% users.forEach(function(user) { %>
     /usr/lib/vmware/auth/bin/adduser -s /bin/sh -G root -h / -D <%=user.name%>
-    echo <%=user.plainPassword%> | passwd <%=user.name%> --stdin
+    echo <%-user.plainPassword%> | passwd <%=user.name%> --stdin
     <% if (typeof user.sshKey !== 'undefined') { %>
         echo "mkdir /etc/ssh/keys-<%=user.name%>" >> /vmfs/volumes/datastore1/rackhd_create_sshkeys
         echo "echo <%=user.sshKey%> > /etc/ssh/keys-<%=user.name%>/authorized_keys" >> /vmfs/volumes/datastore1/rackhd_create_sshkeys

--- a/data/templates/install-debian/debian-preseed
+++ b/data/templates/install-debian/debian-preseed
@@ -194,7 +194,7 @@ d-i passwd/root-login boolean true
 d-i passwd/make-user boolean false
 # Root password, either in clear text
 # or encrypted using an MD5 hash.
-d-i passwd/root-password-crypted password <%=rootEncryptedPassword%>
+d-i passwd/root-password-crypted password <%-rootEncryptedPassword%>
 
 ### Package selection
 # Individual additional packages to install

--- a/data/templates/install-debian/post-install-debian.sh
+++ b/data/templates/install-debian/post-install-debian.sh
@@ -11,9 +11,9 @@ chown -R root:root /root/.ssh
 <% if (typeof users !== 'undefined') { -%>
 <% users.forEach(function(user) { -%>
     <%_ if (undefined !== user.uid) { _%>
-        useradd -u <%=user.uid%> -m -p '<%=user.encryptedPassword%>' <%=user.name%>
+        useradd -u <%=user.uid%> -m -p '<%-user.encryptedPassword%>' <%=user.name%>
     <%_ } else {_%>
-        useradd -m -p '<%=user.encryptedPassword%>' <%=user.name%>
+        useradd -m -p '<%-user.encryptedPassword%>' <%=user.name%>
     <%_ } _%>
     <%_ if (undefined !== user.sshKey) { _%>
 mkdir /home/<%=user.name%>/.ssh

--- a/data/templates/install-photon/photon-os-ks
+++ b/data/templates/install-photon/photon-os-ks
@@ -1,11 +1,12 @@
 {
+    <!-- # Copyright 2016-2018, Dell EMC, Inc. -->
     <%_ if (typeof hostname !== 'undefined') { _%>
     "hostname": "<%=hostname%>",
     <%_ } _%>
     "password":
         {
             "crypted": false,
-            "text": "<%=rootPassword%>"
+            "text": "<%-rootPassword%>"
         },
     "disk": "<%=installDisk%>",
     "type": "<%=installType%>",

--- a/data/templates/install-photon/post-install-photon.sh
+++ b/data/templates/install-photon/post-install-photon.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Copyright 2016-2018, Dell EMC, Inc.
 
 <%_ if ('undefined' !== typeof networkDevices) { _%>
 ## Set network interfaces
@@ -82,9 +83,9 @@ sed -i "${line}i 127.0.0.1\t<%=hostname%>.<%=domain%>\t<%=hostname%>" /etc/hosts
 # Set user info
     <%_ users.forEach(function(user) { _%>
         <%_ if ('uid' in user) { _%>
-useradd -m '<%=user.name%>' -p '<%=user.encryptedPassword%>' -u <%=user.uid%>
+useradd -m '<%=user.name%>' -p '<%-user.encryptedPassword%>' -u <%=user.uid%>
         <%_ } else { _%>
-useradd -m '<%=user.name%>' -p '<%=user.encryptedPassword%>'
+useradd -m '<%=user.name%>' -p '<%-user.encryptedPassword%>'
         <%_ } _%>
         <%_ if ('sshKey' in user) { _%>
 mkdir /home/<%=user.name%>/.ssh

--- a/data/templates/pxe-cloud-config.yml
+++ b/data/templates/pxe-cloud-config.yml
@@ -1,4 +1,5 @@
 #cloud-config
+# Copyright 2016-2018, Dell EMC, Inc.
 coreos:
   update:
     reboot-strategy: best-effort
@@ -50,7 +51,7 @@ hostname: <%=hostname%>
   <% users.forEach(function(user) { %>
 users:
   - name: "<%=user.name%>"
-    passwd: "<%=user.encryptedPassword%>"
+    passwd: "<%-user.encryptedPassword%>"
 <% if ( user.sshKey) { %>
     ssh-authorized-keys:
       - "<%=user.sshKey%>"

--- a/data/templates/remove_bmc_credentials.sh
+++ b/data/templates/remove_bmc_credentials.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright 2016-2018, Dell EMC, Inc.
 
 usernames=(<%= users.join(" ") %>)
 

--- a/data/templates/secure_erase.py
+++ b/data/templates/secure_erase.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2016, EMC, Inc.
+# Copyright 2016-2018, Dell EMC, Inc.
 
 # -*- coding: UTF-8 -*-
 

--- a/data/templates/set_bmc_credentials.sh
+++ b/data/templates/set_bmc_credentials.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# Copyright 2016-2018, DELL EMC, Inc.
+
 channel=''
 function set_channel()
 {
@@ -40,7 +42,7 @@ for x in $cmdReturn; do
    userNumber=${myarray[$(($i-1))]}
    echo "Username already present, overwriting existing user"
    ipmitool user set name $userNumber <%=user%>
-   ipmitool user set password $userNumber <%=password%>
+   ipmitool user set password $userNumber <%-password%>
    ipmitool channel setaccess $channel $userNumber callin=on ipmi=on link=on privilege=4
    ipmitool user enable $userNumber
    check=$((check + 1))
@@ -77,7 +79,7 @@ if [ $check == 0 ]; then
  echo "Creating a new user"
  get_newUserNumber
  ipmitool user set name $newUserNumber <%=user%>
- ipmitool user set password $newUserNumber <%=password%>
+ ipmitool user set password $newUserNumber <%-password%>
  ipmitool channel setaccess $channel $newUserNumber callin=on ipmi=on link=on privilege=4
  ipmitool user enable $newUserNumber
 exit

--- a/data/templates/suse-autoinst.xml
+++ b/data/templates/suse-autoinst.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!-- # Copyright 2016-2018, DELL EMC, Inc. -->
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
 
@@ -24,7 +25,7 @@
       <fullname>root</fullname>
       <gid>0</gid>
       <uid>0</uid>
-      <user_password><%=rootEncryptedPassword%></user_password>
+      <user_password><%-rootEncryptedPassword%></user_password>
       <username>root</username>
     </user>
 
@@ -36,7 +37,7 @@
   <% if( undefined !== user.uid ) { %>
       <uid><%=user.uid%></uid>
   <% } %>
-      <user_password><%=user.encryptedPassword%></user_password>
+      <user_password><%-user.encryptedPassword%></user_password>
       <username><%=user.name%></username>
     </user>
 <% }) %>

--- a/data/templates/unattend_server2012.xml
+++ b/data/templates/unattend_server2012.xml
@@ -85,13 +85,13 @@
             </OOBE>
             <UserAccounts>
                 <AdministratorPassword>
-                    <Value><%=password%></Value>
+                    <Value><%-password%></Value>
                     <PlainText>true</PlainText>
                 </AdministratorPassword>
                 <LocalAccounts>
                     <LocalAccount wcm:action="add">
                         <Password>
-                            <Value><%=password%></Value>
+                            <Value><%-password%></Value>
                             <PlainText>true</PlainText>
                         </Password>
                         <Description>Local Administrator</Description>
@@ -131,7 +131,7 @@
             </FirstLogonCommands>
             <AutoLogon>
                 <Password>
-                    <Value><%=password%></Value>
+                    <Value><%-password%></Value>
                     <PlainText>true</PlainText>
                 </Password>
                 <Enabled>true</Enabled>

--- a/data/templates/winpe-kickstart.ps1
+++ b/data/templates/winpe-kickstart.ps1
@@ -1,3 +1,4 @@
+# Copyright 2016-2018, Dell EMC, Inc.
 # The progress notification is just something nice-to-have, so progress notification failure should
 # never impact the normal installation process
 <% if( typeof progressMilestones !== 'undefined' && progressMilestones.startInstallerUri ) { %>
@@ -12,7 +13,7 @@ catch
 }
 <% } %>
 $repo = "<%=smbRepo%>"
-$smb_passwd = "<%=smbPassword%>"
+$smb_passwd = "<%-smbPassword%>"
 $smb_user = "<%=smbUser%>"
 Start-Sleep -s 2
 net use w: ${repo} ${smb_passwd} /user:${smb_user}


### PR DESCRIPTION
**Background**

Users need to include special character in password, such as `&`. But password is escaped in the templates currently, e.g. `&` is escaped into `&amp;`.
https://rackhd.atlassian.net/browse/RAC-6602

**Done**

* Replace `<%=` with `<%-` for password.

@RackHD/corecommitters @panpan0000 @nortonluo 