### PR TITLE
Separate ssh-job into ssh-command and ssh-catalog

### DIFF
--- a/lib/graphs/esxcli-driver-version-commands-graph.js
+++ b/lib/graphs/esxcli-driver-version-commands-graph.js
@@ -19,7 +19,7 @@ module.exports = {
             taskDefinition: {
                 injectableName: "Task.Run.Ssh",
                 friendlyName: "Ssh and run Esxi commands",
-                implementsTask: 'Task.Base.Ssh',
+                implementsTask: 'Task.Base.Ssh.Catalog',
                 options: {
                     commands: null
                 },

--- a/lib/graphs/examples/install-chef-graph.js
+++ b/lib/graphs/examples/install-chef-graph.js
@@ -26,7 +26,7 @@ module.exports = {
             taskDefinition: {
                 friendlyName: "Task.Get.Chef.Installer",
                 injectableName: "Task.Chef.GetInstaller",
-                implementsTask: "Task.Base.Ssh",
+                implementsTask: "Task.Base.Ssh.Command",
                 options: {
                     chefIP: null,
                     domainName: null,
@@ -51,7 +51,7 @@ module.exports = {
             taskDefinition: {
                 injectableName: "Task.Run.Client",
                 friendlyName: "Ssh and run Chef client",
-                implementsTask: 'Task.Base.Ssh',
+                implementsTask: 'Task.Base.Ssh.Command',
                 options: {
                     name: null,
                     commands: "sudo /usr/bin/chef-client -N {{options.name || task.nodeId}}"

--- a/lib/graphs/examples/install-chef-server-graph.js
+++ b/lib/graphs/examples/install-chef-server-graph.js
@@ -24,7 +24,7 @@ module.exports = {
             taskDefinition: {
                 friendlyName: "Install Chef",
                 injectableName: "Task.Chef.InstallCore",
-                implementsTask: "Task.Base.Ssh",
+                implementsTask: "Task.Base.Ssh.Command",
                 options: {
                     domainName: null,
                     chefDest: null,
@@ -47,7 +47,7 @@ module.exports = {
             taskDefinition: {
                 injectableName: "Task.Run.Client",
                 friendlyName: "Ssh and run Chef client",
-                implementsTask: 'Task.Base.Ssh',
+                implementsTask: 'Task.Base.Ssh.Command',
                 options: {
                     commands: "sudo chef-server-ctl reconfigure"
                 },
@@ -62,7 +62,7 @@ module.exports = {
             taskDefinition: {
                 injectableName: "Task.Chef.User.Add",
                 friendlyName: "add user",
-                implementsTask: 'Task.Base.Ssh',
+                implementsTask: 'Task.Base.Ssh.Command',
                 options: {
                     username: null,
                     firstName: null,
@@ -88,7 +88,7 @@ module.exports = {
             taskDefinition: {
                 injectableName: "Task.Run.Client",
                 friendlyName: "add user",
-                implementsTask: 'Task.Base.Ssh',
+                implementsTask: 'Task.Base.Ssh.Command',
                 options: {
                     sshExecOptions: null,
                     shortName: null,


### PR DESCRIPTION
**Background**

This is to fix "No parser" issue:
```
No parser exists for command sudo ./megaraid-config.sh
No parser exists for command sudo python set_interfaces.py 
No parser exists for command sudo ipmitool chassis bootdev pxe
```

https://rackhd.atlassian.net/browse/RAC-6579

**Done**

* Separate ssh-job into ssh-command and ssh-catalog

depends on: https://github.com/RackHD/on-tasks/pull/580

@RackHD/corecommitters @pengz1 @nortonluo 