### PR TITLE
Fix Debian/Ubuntu kernel panic on EFI

### DIFF
--- a/data/profiles/install-debian.ipxe
+++ b/data/profiles/install-debian.ipxe
@@ -9,7 +9,7 @@ echo Starting Debian/Ubuntu x64 installer for ${hostidentifier}
 set base-url <%=repo%>/<%=baseUrl%>
 kernel ${base-url}/linux
 initrd ${base-url}/initrd.gz
-imgargs linux auto=true nomodeset fb=false DEBIAN_FRONTEND=noninteractive url=<%=installScriptUri%> hostname=<%=hostname%> log_host=<%=server%> BOOTIF=01-<%=macaddress%> interface=<%=interface%> console=<%=comport%>,115200n8 console=tty0 raid=noautodetect <%=kargs%>
+imgargs linux initrd=initrd.gz auto=true nomodeset fb=false DEBIAN_FRONTEND=noninteractive url=<%=installScriptUri%> hostname=<%=hostname%> log_host=<%=server%> BOOTIF=01-<%=macaddress%> interface=<%=interface%> console=<%=comport%>,115200n8 console=tty0 raid=noautodetect <%=kargs%>
 
 <% if( typeof progressMilestones !== 'undefined' && progressMilestones.startInstallerUri ) { %>
     imgfetch --name fakedimage http://<%=server%>:<%=port%><%-progressMilestones.startInstallerUri%> ||


### PR DESCRIPTION
Fixing kernel panic error during EFI boot on debian and ubuntu installation . 

`kernel panic not syncing vfs unable to mount root fs on unknown-block (1,0)`