### PR TITLE
modprobe ipmi_si in rancher os

### DIFF
--- a/data/templates/cloud-config.yaml
+++ b/data/templates/cloud-config.yaml
@@ -7,6 +7,7 @@ write_files:
     content: |
       #!/bin/bash
       modprobe ipmi_devintf
+      modprobe ipmi_si
       wget -O /tmp/micro.tar.xz <%= dockerUri %>
       while [ $(docker images | grep -c micro) == "0" ]; do
          xz -cd /tmp/micro.tar.xz | docker load


### PR DESCRIPTION
My inspur server needs to modprobe ipmi_si during discovery.