### PR TITLE
[RAC-6682] Add lookup update in post WSMAN device discovery

### DIFF
--- a/lib/graphs/dell-wsman-post-discovery-graph.js
+++ b/lib/graphs/dell-wsman-post-discovery-graph.js
@@ -29,6 +29,14 @@ module.exports = {
             ignoreFailure: true
         },
         {
+            label: 'update-lookups',
+            taskName: 'Task.Wsman.Update.Lookups',
+            waitOn: {
+                'dell-wsman-get-bios': 'succeeded'
+            },
+            ignoreFailure: true
+        },
+        {
              label: 'create-wsman-pollers',
              taskDefinition: {
                   friendlyName: 'Create Default Pollers',
@@ -49,15 +57,8 @@ module.exports = {
                   }
              },
              waitOn: {
-              'dell-wsman-get-bios': 'succeeded'
+              'update-lookups': 'finished'
              }
-        },
-        {
-            label: 'update-lookups',
-            taskName: 'Task.Wsman.Update.Lookups',
-            waitOn: {
-                'create-wsman-pollers': 'succeeded'
-            }
         }
     ]
 };

--- a/lib/graphs/dell-wsman-post-discovery-graph.js
+++ b/lib/graphs/dell-wsman-post-discovery-graph.js
@@ -51,6 +51,13 @@ module.exports = {
              waitOn: {
               'dell-wsman-get-bios': 'succeeded'
              }
+        },
+        {
+            label: 'update-lookups',
+            taskName: 'Task.Wsman.Update.Lookups',
+            waitOn: {
+                'create-wsman-pollers': 'succeeded'
+            }
         }
     ]
 };


### PR DESCRIPTION
## Background
The node discovered by WSMAN discovery workflow have no mac lookup entry associated with it. This is because the traditional micro kernel discovery way have a step to update lookup table but WSMAN do not.

## Solution 
Add a task to use the MAC address in node catalog to update lookup table. This task will be execute in the post WSMAN discovery workflow after get WSMAN inventory.

depends on:https://github.com/RackHD/on-tasks/pull/587

@lanchongyizu @pengz1 @iceiilin @markbeierl 