### PR TITLE
Adding switch deiscovery for Dell s6000

### DIFF
--- a/data/profiles/dell-onie.sh
+++ b/data/profiles/dell-onie.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+# Copyright 2018, DELL EMC, Inc.
+
+
+TASKS_URI="http://<%=server%>:<%=port%>/api/2.0/tasks/<%=identifier%>"
+echo $TASKS_URI
+LOGFILE="/var/log/rackhd.log"
+
+# tasks will be downloaded to:
+# /tmp/mytask.json
+getTask(){
+    wget $TASKS_URI -O /tmp/mytask.json
+}
+
+# Once the task is excecuted and updated
+# post task will post it to TASKS_URI
+postTask(){
+    # Below is an example of expected data
+    # DATA='{"identifier":"5ace33a577a36e54bf23bcba","tasks":[{"stdout":"{\"version\":\"1.2.3.4\"}","source":"version","format":"json","catalog":true}]}'
+    read DATA</tmp/mytask.json
+    echo "$DATA" >> $LOGFILE
+    wget --post-data=$DATA --header="Content-Type: application/json" $TASKS_URI
+}
+
+# Args:
+# $1 key
+# return : key value
+getValue(){
+    grep -o "\"${1}\":*\"[^\"]*\"" /tmp/mytask.json | grep -o '"[^"]*"$'  | tr -d '"'
+}
+
+# If the loaded task contains a Download URI; Download & execute
+# key we are looking for is: downloadUrl
+executeUrl(){
+    DOWNLOAD_URL=$( getValue downloadUrl);
+    echo " downloaded URL $DOWNLOAD_URL" >> $LOGFILE
+    if [ ! -z $DOWNLOAD_URL ]; then
+        RESP='"'$( wget -O - $DOWNLOAD_URL | sh 2>&1 )'"'
+        if [ $? -ne 0 ]; then           
+           echo Error: $RESP
+           RESP=$( echo $RESP | tr ' ' '_' )                 
+           # Add error to the pulled task
+           sed -i '$s/}/,"error":'"${RESP}"'}/' /tmp/mytask.json
+        fi
+    fi
+}
+
+# main
+while true;
+do
+  # Pull tasks from RackHD
+  getTask
+  # If there is any tasks; proceed
+  # othewise, wait 30 seconds and try again
+  if [ $? = 0 ]
+  then
+      #check for exit task
+      EXIT=$( grep -o '"exit"' /tmp/mytask.json)
+      executeUrl
+      postTask
+      # if the tasks contains "exit" command; exit this loop
+      if [ $EXIT == '"exit"' ]
+      then
+         return 0
+      fi;
+      sleep 10;
+  else
+      sleep 30;
+  fi;
+done;
+#TODO upload task result
+

--- a/data/templates/dell-catalog-sysinfo.sh
+++ b/data/templates/dell-catalog-sysinfo.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+# Copyright 2018, DELL EMC, Inc.
+OPEN_CURLY='{'
+CLOSE_CURLY='}'
+
+# using onie-sysinfo
+# onie-sysinfo [-hsevimrpcfdatP]
+# Dump ONIE system information.
+
+# COMMAND LINE OPTIONS
+
+#         The default is to dump the ONIE platform (-p).
+#         -h
+#                 Help.  Print this message.
+#         -s
+#                 Serial Number
+#         -P
+#                 Part Number
+#         -e
+#                 Management Ethernet MAC address
+#         -v
+#                 ONIE version string
+#         -i
+#                 ONIE vendor ID.  Print the ONIE vendor's IANA enterprise number.
+#         -m
+#                 ONIE machine string
+#         -r
+#                 ONIE machine revision string
+#         -p
+#                 ONIE platform string.  This is the default.
+#         -c
+#                 ONIE CPU architecture
+#         -f
+#                 ONIE configuration version
+#         -d
+#                 ONIE build date
+#         -t
+#                 ONIE partition type
+#         -a
+#                 Dump all information.
+# Commands to run
+# Collecting version and serial nb
+VERSION=$( onie-sysinfo -v )
+SERIAL_NB=$( onie-sysinfo -s)
+
+
+# build the stdout data in json format
+STDOUT='"'$OPEN_CURLY'
+\\\\"version\\\\":\\\\"'$VERSION'\\\\",
+\\\\"serialNb\\\\":\\\\"'$SERIAL_NB'\\\\"
+'$CLOSE_CURLY'"'
+
+#remove white space from stdout
+STDOUT=$( echo $STDOUT | tr -d ' ')
+
+# Finally, Add stdout to the pulled task
+sed -i '$s/}/,"stdout":'${STDOUT}'}/' /tmp/mytask.json

--- a/lib/graphs/dell-switch-discovery-graph.js
+++ b/lib/graphs/dell-switch-discovery-graph.js
@@ -1,0 +1,27 @@
+// Copyright 2018, Dell EMC, Inc.
+
+"use strict";
+
+module.exports = {
+    "friendlyName": "Dell Switch Onie Discovery",
+    "injectableName": "Graph.Switch.Discovery.Dell.Onie",
+    "tasks": [
+        {
+            "label": "catalog-switch",
+            "taskDefinition": {
+                "friendlyName": "Catalog Dell Switch",
+                "injectableName": "Task.Inline.Catalog.Switch.Dell",
+                "implementsTask": "Task.Base.Linux.Commands",
+                "options": {
+		    "commands": [
+                        {
+                            "downloadUrl": "{{ api.templates }}/dell-catalog-sysinfo.sh?nodeId={{ task.nodeId }}",
+                            "catalog": { "format": "json", "source": "sysinfo" }
+                        }
+                    ]
+                },
+                "properties": {}
+            }
+        }
+    ]
+};

--- a/lib/services/profile-api-service.js
+++ b/lib/services/profile-api-service.js
@@ -232,6 +232,9 @@ function profileApiServiceFactory(
         } else if (vendor === 'arista') {
             configuration.options['vendor-discovery-graph'].graphName =
                 'Graph.Switch.Discovery.Arista.Ztp';
+        } else if (vendor === 'dell') {
+            configuration.options['vendor-discovery-graph'].graphName =
+                'Graph.Switch.Discovery.Dell.Onie';          
         } else {
             throw new Errors.BadRequestError('Unknown switch vendor ' + vendor);
         }
@@ -291,7 +294,7 @@ function profileApiServiceFactory(
         throw err;
     };
 
-    ProfileApiService.prototype.getProfileFromTaskOrNode = function(node) {
+    ProfileApiService.prototype.getProfileFromTaskOrNode = function(node, vendor) {
         var self = this;
         var defaultProfile;
 
@@ -301,7 +304,11 @@ function profileApiServiceFactory(
             // python script right away, and start downloading
             // and executing tasks governed by the switch-specific
             // discovery workflow.
-            defaultProfile = 'taskrunner.py';
+            if(vendor === 'dell'){
+                defaultProfile = 'dell-onie.sh';
+            } else {
+                defaultProfile = 'taskrunner.py';
+            }
         } else {
             defaultProfile = 'redirect.ipxe';
         }
@@ -332,8 +339,9 @@ function profileApiServiceFactory(
                                     switchVendor = "brocade";
                                 }else if(taskgraphInstance.injectableName === "Graph.Switch.Discovery.Cisco.Poap"){
                                     switchVendor = "cisco";
+                                } else if(taskgraphInstance.injectableName === "Graph.Switch.Discovery.Dell.Onie"){
+                                    switchVendor = "dell";
                                 }
-
                                 _options = {
                                     identifier: node.id,
                                     switchVendor : switchVendor
@@ -424,7 +432,7 @@ function profileApiServiceFactory(
 
                 return self.getNode(macAddresses, options)
                     .then(function (node) {
-                        return self.getProfileFromTaskOrNode(node, 'compute')
+                        return self.getProfileFromTaskOrNode(node)
                             .then(function (render) {
                                 return _.defaults(render, {
                                     ignoreLookup: res.locals.macAddress ? true : false
@@ -463,7 +471,7 @@ function profileApiServiceFactory(
                 return self.getNode(macAddresses, options);
             })
             .then(function(node) {
-                return self.getProfileFromTaskOrNode(node, 'switch');
+                return self.getProfileFromTaskOrNode(node, vendor);
             })
             .catch(function (err) {
                 throw err;


### PR DESCRIPTION
- It uses Onie discovery to load a shell script (taskrunner)
- Currently we collect version and serial nb

- To enable this feature, the user has to configure the dhcp server as follow:
`
class "dellswitch" {
        match if substring (hardware, 1, 6) = 4c:76:25:f6:64:00;
}
pool {
        allow members of "dellswitch";
        range 172.31.128.241 172.31.128.250;
        option default-url = "http://172.31.128.1:9030/api/current/profiles/switch/dell";
}`
Next step : 
- Adding a script to load os image using onie discovery

## Here is an example of data created  after discovery:

- Catalog:
`[
  {
    "id": "8c5128cc-6075-44b6-acc5-b2936b0edc73",
    "node": "/api/2.0/nodes/5acf85bae595224a77b7f5da",
    "createdAt": "2018-04-12T16:13:48.885Z",
    "updatedAt": "2018-04-12T16:13:48.885Z",
    "source": "sysinfo",
    "data": {
      "version": "3.25.1.2",
      "serialNb": "CN0WKFYN7793164F0017"
    }
  }
]`

- Created node:
`{
    "autoDiscover": false,
    "catalogs": "/api/2.0/nodes/5acf85bae595224a77b7f5da/catalogs",
    "id": "5acf85bae595224a77b7f5da",
    "identifiers": [
      "4c:76:25:f6:64:00"
    ],
    "name": "4c:76:25:f6:64:00",
    "obms": [],
    "tags": "/api/2.0/nodes/5acf85bae595224a77b7f5da/tags",
    "pollers": "/api/2.0/nodes/5acf85bae595224a77b7f5da/pollers",
    "relations": [],
    "sku": null,
    "type": "switch",
    "workflows": "/api/2.0/nodes/5acf85bae595224a77b7f5da/workflows",
    "ibms": []
  }`