### PR TITLE
Add support for dell switch discoveryand add basic configuration 

### DIFF
--- a/data/profiles/dell-bmp.sh
+++ b/data/profiles/dell-bmp.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+
+# Copyright 2018, DELL EMC, Inc.
+
+TASKS_URI="http://<%=server%>:<%=port%>/api/2.0/tasks/<%=identifier%>"
+echo $TASKS_URI
+LOGFILE="/tmp/rackhd.log"
+
+# tasks will be downloaded to:
+# /tmp/mytask.json
+getTask(){
+    curl -X GET -s -w '%{http_code}' $TASKS_URI -o /tmp/mytask.json    
+}
+
+# Once the task is excecuted and updated
+# post task will post it to TASKS_URI
+postTask(){
+    # Below is an example of expected data
+    # DATA='{"identifier":"5aeb28b34e9d8e96b83877b1","tasks":[{"stdout":"{\"version\":\"1.2.3.4\"}","source":"version","format":"json","catalog":true}]}'
+    read DATA</tmp/mytask.json
+    echo "$DATA" >> $LOGFILE
+    curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' -d @/tmp/mytask.json $TASKS_URI
+}
+
+# Args:
+# $1 key
+# return : key value
+getValue(){
+    grep -o "\"${1}\":*\"[^\"]*\"" /tmp/mytask.json | grep -o '"[^"]*"$'  | tr -d '"'
+}
+
+# If the loaded task contains a Download URI; Download & execute
+# key we are looking for is: downloadUrl
+executeUrl(){
+    DOWNLOAD_URL=$( getValue downloadUrl);
+    echo " downloaded URL $DOWNLOAD_URL" >> $LOGFILE
+    if [ ! -z $DOWNLOAD_URL ]; then
+        if [[ $DOWNLOAD_URL = *".exp"* ]]; then
+            echo "Run expect script"
+            RESP='"'$( curl  -o - $DOWNLOAD_URL | expect 2>&1 )'"'
+            # Assuming that the .exp is a configuration script,
+            # the network is disconnected until we exit the configuration bmp mode
+            # We need to exit bmp and then update RackHD task to finish the workflow
+            (n=0; until [ $n -ge 5 ]; do postTask && break; n=$[$n+1]; sleep 15; done;) &
+            echo "exit taskrunner"
+            exit 0
+        else
+            RESP='"'$( curl -s -o - $DOWNLOAD_URL | sh 2>&1 )'"'
+        fi
+    fi
+    if [ $? -ne 0 ]; then
+       echo Error: $RESP
+       # Add error to the pulled task
+       sed -e '$s/}/,"error":'"${RESP}"'}/' /tmp/mytask.json | tee /tmp/mytask.json
+    fi
+}
+
+# main
+while :
+do
+  echo "Pull tasks from RackHD"
+  RESP=$( getTask)
+  echo "get task return $?" >> $LOGFILE
+  # If there is any tasks; proceed
+  # othewise, wait 30 seconds and try again
+  if [ $?=0 ] && [ $RESP -eq 200 ]
+  then
+      #check for exit task
+      EXIT=$( grep -o '"exit"' /tmp/mytask.json || echo "failed" )
+      executeUrl
+      postTask
+      # if the tasks contains "exit" command; exit this loop
+      if [ $EXIT == '"exit"' ]
+      then
+         echo " Don't Exit; We need the task runner to stay up for the next task"
+         # skip exit for now
+         #return 0
+      fi;
+      sleep 10;
+  else
+      sleep 120;
+  fi;  
+done;
+#TODO upload task result
+

--- a/data/templates/dell-switch-basic-config.exp
+++ b/data/templates/dell-switch-basic-config.exp
@@ -1,0 +1,150 @@
+#!/usr/bin/expect
+#/DELL-FORCE10
+# Copyright 2018, Dell EMC, Inc.
+
+############FUNCTIONS############
+#access the switch CLI via Dell 'f10do' shell command and execute FTOS command
+proc execFtosCommand {cmd_str} {
+ set str [exec f10do "$cmd_str"]
+ print_output $str
+}
+########Logging Functions########
+#print to terminal and to log file
+proc print_output {str {fd ""}} {
+ puts $str
+ if {$fd != ""} {
+ puts $fd $str
+ }
+}
+#starts logging status
+proc startLogging {} {
+ global status_file
+ global fp
+ set status_file "/tmp/rackhd.log"
+ #open status file
+ set fp [open $status_file w]
+}
+#stop logging status
+proc stopLogging {} {
+ global fp
+ print_output "========================================\n" $fp
+ close $fp
+}
+#####Prereq Check Functions######
+#resets watchdog timer
+proc resetTimer {} {
+ print_output [exec rstimer 30]
+ print_output "\nReset Timer Complete!\n"
+}
+########Config Functions#########
+#write changes to startup-config
+proc doWrite {} {
+ execFtosCommand "write"
+ #wait 2 seconds
+ after 2000
+}
+#configures management interface with IP address
+proc setManagement {} {
+ global fp
+ print_output "Configuring ManagementEthernet <%=mgmtPort%> ...\n" $fp
+ execFtosCommand "configure terminal"
+ execFtosCommand "interface managementEthernet <%=mgmtPort%>"
+ execFtosCommand "ip address <%=ipAddr%>"
+ execFtosCommand "no shut"
+ execFtosCommand "end"
+}
+#enable ssh
+proc enableSsh {} {
+  global fp
+  print_output "Configuring ssh ...\n" $fp
+  execFtosCommand "configure terminal"
+  execFtosCommand "ip ssh server enable"
+  execFtosCommand "end"
+}
+#create an account
+proc createAccount {} {
+  global fp
+  print_output "Create an new account ...\n" $fp
+  execFtosCommand "configure terminal"
+  execFtosCommand "username <%=username%> password <%=userPassword%>"
+  execFtosCommand "end"
+}
+#set admin password
+proc updateAdminPassword {} {
+  global fp
+  print_output "update admin password ...\n" $fp
+  execFtosCommand "configure terminal"
+  execFtosCommand "enable password  level 15 0 <%=adminPassword%>"
+  execFtosCommand "end"
+}
+
+#################################
+#translate CR and LF correctly
+fconfigure stdout -translation crlf
+fconfigure stderr -translation crlf
+#flag variables to confirm if initial check and configuration pass/succeed
+set checkFail 0
+set configFail 0
+#name to set the switch to
+set hostname <%=hostname%>"
+print_output "!!!Executing Config Script!!!\n"
+#set Unix watchdog timer to 30 minutes
+if [catch resetTimer] {
+ print_output "Error encountered during watchdog timer reset!\n"
+ set checkFail 1
+ exit 2
+}
+#start logging
+if [catch startLogging] {
+ print_output "Error encountered during start of logging!\n"
+} else {
+ print_output "Status logging for bmp successfully started!\n" $fp
+}
+print_output "========================================\n" $fp
+print_output " Status: $hostname\n" $fp
+print_output "========================================\n" $fp
+#set the management IP address
+if [catch setManagement] {
+ print_output "Error configuring management!\n" $fp
+ set configFail 1
+}
+#Enable SSH
+if [catch enableSsh] {
+  print_output "Error enabling ssh"
+  set configFail 1
+}
+#create a new account
+if [catch createAccount] {
+  print_output "Error creating a new account"
+  set configFail 1
+}
+#updating admin password
+if [catch updateAdminPassword] {
+  print_output "Error updaing admin password"
+  set configFail 1
+}
+#write the configuration to startup-config
+if [catch doWrite] {
+ print_output "Error saving configuration!\n" $fp
+ set configFail 1
+}
+
+#NOTIFY IF CONFIGURATION FAILED OR PASSED
+if {$configFail} {
+ print_output "\n!!!!!Errors were encountered during configuration - check log file!!!!!\n" $fp
+} else {
+ print_output "\n!!!!!Configuration Successfully Applied!!!!!\n" $fp
+}
+
+#stop logging to status file
+if [catch stopLogging] {
+ print_output "Error upon stopping logging!\n" $fp
+ exit 2
+}
+#IF CONFIGURATION FAILED, EXIT ON ERROR, OR, IF PASSED, EXIT ON SUCCESS
+if {$configFail} {
+ exit 2
+} else {
+ exit 0
+}
+

--- a/data/templates/dell-switch-catalog.sh
+++ b/data/templates/dell-switch-catalog.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Copyright 2018, DELL EMC, Inc.
+OPEN_CURLY='{'
+CLOSE_CURLY='}'
+LOGFILE="/tmp/rackhd.log"
+
+OS_VERSION=$( f10do "show system" | grep 'Dell EMC Networking OS Version' | awk -F: '{print $NF}' | tr -d '[:space:]')
+STACK_MAC=$( f10do "show system" | grep 'Stack MAC' | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}')
+MODUL_TYPE=$( f10do "show system" | grep 'Module Type' | awk -F: '{print $NF}' | tr -d '[:space:]')
+
+# build the stdout data in json format
+STDOUT='"'$OPEN_CURLY'
+\\\\\\"osVersion\\\\\\":\\\\\\"'$OS_VERSION'\\\\\\",
+\\\\\\"stackMack\\\\\\":\\\\\\"'$STACK_MAC'\\\\\\",
+\\\\\\"moduleType\\\\\\":\\\\\\"'$MODUL_TYPE'\\\\\\"
+'$CLOSE_CURLY'"'
+
+#remove white space from stdout
+STDOUT=$( echo $STDOUT | tr -d ' ')
+echo $STDOUT >> $LOGFILE
+# Finally, Add stdout to the pulled task
+sed -e '$s/}/,"stdout":'${STDOUT}'}/' /tmp/mytask.json | tee /tmp/mytask.json

--- a/data/templates/dell-switch-onie-catalog.sh
+++ b/data/templates/dell-switch-onie-catalog.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+# Copyright 2018, DELL EMC, Inc.
+OPEN_CURLY='{'
+CLOSE_CURLY='}'
+
+# using onie-sysinfo
+# onie-sysinfo [-hsevimrpcfdatP]
+# Dump ONIE system information.
+
+# COMMAND LINE OPTIONS
+
+#         The default is to dump the ONIE platform (-p).
+#         -h
+#                 Help.  Print this message.
+#         -s
+#                 Serial Number
+#         -P
+#                 Part Number
+#         -e
+#                 Management Ethernet MAC address
+#         -v
+#                 ONIE version string
+#         -i
+#                 ONIE vendor ID.  Print the ONIE vendor's IANA enterprise number.
+#         -m
+#                 ONIE machine string
+#         -r
+#                 ONIE machine revision string
+#         -p
+#                 ONIE platform string.  This is the default.
+#         -c
+#                 ONIE CPU architecture
+#         -f
+#                 ONIE configuration version
+#         -d
+#                 ONIE build date
+#         -t
+#                 ONIE partition type
+#         -a
+#                 Dump all information.
+# Commands to run
+# Collecting version and serial nb
+VERSION=$( onie-sysinfo -v )
+SERIAL_NB=$( onie-sysinfo -s)
+
+
+# build the stdout data in json format
+STDOUT='"'$OPEN_CURLY'
+\\\\"version\\\\":\\\\"'$VERSION'\\\\",
+\\\\"serialNb\\\\":\\\\"'$SERIAL_NB'\\\\"
+'$CLOSE_CURLY'"'
+
+#remove white space from stdout
+STDOUT=$( echo $STDOUT | tr -d ' ')
+
+# Finally, Add stdout to the pulled task
+sed -i '$s/}/,"stdout":'${STDOUT}'}/' /tmp/mytask.json

--- a/lib/graphs/dell-onie-switch-discovery-graph.js
+++ b/lib/graphs/dell-onie-switch-discovery-graph.js
@@ -3,8 +3,8 @@
 "use strict";
 
 module.exports = {
-    "friendlyName": "Dell Switch Bmp Discovery",
-    "injectableName": "Graph.Switch.Discovery.Dell.Bmp",
+    "friendlyName": "Dell Switch Onie Discovery",
+    "injectableName": "Graph.Switch.Discovery.Dell.Onie",
     "tasks": [
         {
             "label": "catalog-switch",
@@ -15,8 +15,8 @@ module.exports = {
                 "options": {
 		    "commands": [
                         {
-                            "downloadUrl": "{{ api.templates }}/dell-switch-catalog.sh?nodeId={{ task.nodeId }}",
-                            "catalog": { "format": "json", "source": "sysinfo" }
+                            "downloadUrl": "{{ api.templates }}/dell-switch-onie-catalog.sh?nodeId={{ task.nodeId }}",
+                            "catalog": { "format": "json", "source": "onieSysinfo" }
                         }
                     ]
                 },

--- a/lib/graphs/dell-switch-config-graph.js
+++ b/lib/graphs/dell-switch-config-graph.js
@@ -1,0 +1,32 @@
+// Copyright 2018, Dell EMC, Inc.
+
+"use strict";
+
+module.exports = {
+    "friendlyName": "Dell Switch configuration",
+    "injectableName": "Graph.Switch.Dell.Configuration",
+    "tasks": [
+        {
+            "label": "config-switch",
+            "taskDefinition": {
+                "friendlyName": "Dell Switch configuration",
+                "injectableName": "Task.Inline.Switch.Dell.Configuration",
+                "implementsTask": "Task.Base.Linux.Commands",
+                "options": {
+                    "mgmtPort": "1/1",
+                    "username": "rackhd",
+                    "userPassword": "RackHDRocks1!",
+                    "adminPassword": "RackHDRocks1!",
+                    "hostname": "rackhd",
+                    "ipAddr": "dhcp",
+                    "commands": [
+                        {
+                            "downloadUrl": "{{ api.templates }}/dell-switch-basic-config.exp?nodeId={{ task.nodeId }}",
+                        }
+                    ]
+                },
+                "properties": {}
+            }
+        }
+    ]
+};

--- a/lib/services/profile-api-service.js
+++ b/lib/services/profile-api-service.js
@@ -232,9 +232,12 @@ function profileApiServiceFactory(
         } else if (vendor === 'arista') {
             configuration.options['vendor-discovery-graph'].graphName =
                 'Graph.Switch.Discovery.Arista.Ztp';
-        } else if (vendor === 'dell') {
+        } else if (vendor === 'onie') {
             configuration.options['vendor-discovery-graph'].graphName =
                 'Graph.Switch.Discovery.Dell.Onie';          
+        } else if (vendor === 'dell') {
+            configuration.options['vendor-discovery-graph'].graphName =
+                'Graph.Switch.Discovery.Dell.Bmp';          
         } else {
             throw new Errors.BadRequestError('Unknown switch vendor ' + vendor);
         }
@@ -304,8 +307,10 @@ function profileApiServiceFactory(
             // python script right away, and start downloading
             // and executing tasks governed by the switch-specific
             // discovery workflow.
-            if(vendor === 'dell'){
+            if(vendor === 'onie'){
                 defaultProfile = 'dell-onie.sh';
+            } else if(vendor === 'dell'){
+                defaultProfile = 'dell-bmp.sh';
             } else {
                 defaultProfile = 'taskrunner.py';
             }
@@ -340,6 +345,8 @@ function profileApiServiceFactory(
                                 }else if(taskgraphInstance.injectableName === "Graph.Switch.Discovery.Cisco.Poap"){
                                     switchVendor = "cisco";
                                 } else if(taskgraphInstance.injectableName === "Graph.Switch.Discovery.Dell.Onie"){
+                                    switchVendor = "onie";
+                                } else if(taskgraphInstance.injectableName === "Graph.Switch.Discovery.Dell.Bmp"){
                                     switchVendor = "dell";
                                 }
                                 _options = {

--- a/spec/lib/services/profile-api-service-spec.js
+++ b/spec/lib/services/profile-api-service-spec.js
@@ -449,6 +449,53 @@ describe("Http.Services.Api.Profiles", function () {
                 });
         });
 
+        it("render profile pass when having active graph and render succeed with dell bmp", function () {
+            var node = {id: 'test', type: 'switch'};
+            var graph = {context: {}, injectableName: "Graph.Switch.Discovery.Dell.Bmp"};
+
+            this.sandbox.stub(workflowApiService, 'findActiveGraphForTarget').resolves(graph);
+            this.sandbox.stub(taskProtocol, 'requestProfile').resolves('profile');
+            this.sandbox.stub(taskProtocol, 'requestProperties').resolves({});
+
+            return profileApiService.getProfileFromTaskOrNode(node)
+                .then(function (result) {
+                    expect(workflowApiService.findActiveGraphForTarget).to.have.been.calledOnce;
+                    expect(taskProtocol.requestProfile).to.have.been.calledOnce;
+                    expect(taskProtocol.requestProperties).to.have.been.calledOnce;
+                    expect(result).to.deep.equal({
+                        context: {},
+                        options: {
+                            identifier: "test",
+                            switchVendor: "dell"
+                        },
+                        profile: "profile"
+                    });
+                });
+        });
+
+        it("render profile pass when having active graph and render succeed with dell", function () {
+            var node = {id: 'test', type: 'switch'};
+            var graph = {context: {}, injectableName: "Graph.Switch.Discovery.Dell.Onie"};
+
+            this.sandbox.stub(workflowApiService, 'findActiveGraphForTarget').resolves(graph);
+            this.sandbox.stub(taskProtocol, 'requestProfile').resolves('profile');
+            this.sandbox.stub(taskProtocol, 'requestProperties').resolves({});
+
+            return profileApiService.getProfileFromTaskOrNode(node)
+                .then(function (result) {
+                    expect(workflowApiService.findActiveGraphForTarget).to.have.been.calledOnce;
+                    expect(taskProtocol.requestProfile).to.have.been.calledOnce;
+                    expect(taskProtocol.requestProperties).to.have.been.calledOnce;
+                    expect(result).to.deep.equal({
+                        context: {},
+                        options: {
+                            identifier: "test",
+                            switchVendor: "onie"
+                        },
+                        profile: "profile"
+                    });
+                });
+        });
 
         it("render profile pass when having active graph and render succeed", function () {
             var node = {id: 'test', type: 'switch'};


### PR DESCRIPTION
# Changes required outside this repo:

- Assuming 172.31.128.0/22 is our southbound subnet
- Port 9030 is taskgraph listener
- Port 9090 is http server

## dhcp server configuration
`
class "dellswitch" {
  match if substring (hardware, 1, 6) = 4c:76:25:f6:64:02;

}
class "dellonie" {
  match if substring (hardware, 1, 6) = 4c:76:25:f6:64:00;

}
subnet 172.31.128.0 netmask 255.255.255.0 {
  pool{
    allow members of "dellswitch";
    range 172.31.128.4 172.31.128.10;
    option configfile = "http://172.31.128.1:9090/dell-bmp-entrypoint.exp";
  }
  pool{
    allow members of "dellonie";
    range 172.31.128.241 172.31.128.250;
    option default-url = "http://172.31.128.1:9030/api/current/profiles/switch/onie";
  }
}
`
## Http server 
- Create a new file called dell-bmp-entrypoint.exp
`
#!/usr/bin/expect
#/DELL-FORCE10
##Global Variable
############FUNCTIONS############
proc print_output {str} {
 puts $str
}
fconfigure stdout -translation crlf
fconfigure stderr -translation crlf

print_output "!!!Executing Runner!!!\n"

set timeout 12000
spawn curl -o /tmp/taskrunner.sh -s http://172.31.128.1:9030/api/current/profiles/switch/dell
expect eof
spawn chmod +x /tmp/taskrunner.sh
expect eof
spawn /tmp/taskrunner.sh
expect "exit taskrunner"
`
