### PR TITLE
add refresh-catalog tasks after creating raid successfully

### DIFF
--- a/lib/graphs/bootstrap-megaraid-config-graph.js
+++ b/lib/graphs/bootstrap-megaraid-config-graph.js
@@ -54,10 +54,24 @@ module.exports = {
             }
         },
         {
+            "label": "refresh-catalog-driveid",
+            "taskName": "Task.Catalog.Drive.Id",
+            "waitOn": {
+                "refresh-catalog-megaraid": "succeeded"
+            }
+        },
+        {
+            "label": "refresh-catalog-lsall",
+            "taskName": "Task.Catalog.lsall",
+            "waitOn": {
+                "refresh-catalog-driveid": "succeeded"
+            }
+        },
+        {
             label: 'final-reboot',
             taskName: 'Task.Obm.Node.Reboot',
             waitOn: {
-                'refresh-catalog-megaraid': 'finished'
+                'refresh-catalog-lsall': 'finished'
             }
         }
     ]

--- a/lib/graphs/dell-perccli-create-megaraid-graph.js
+++ b/lib/graphs/dell-perccli-create-megaraid-graph.js
@@ -54,10 +54,24 @@ module.exports = {
             }
         },
         {
+            "label": "refresh-catalog-driveid",
+            "taskName": "Task.Catalog.Drive.Id",
+            "waitOn": {
+                "refresh-catalog-megaraid": "succeeded"
+            }
+        },
+        {
+            "label": "refresh-catalog-lsall",
+            "taskName": "Task.Catalog.lsall",
+            "waitOn": {
+                "refresh-catalog-driveid": "succeeded"
+            }
+        },
+        {
             label: 'final-reboot',
             taskName: 'Task.Obm.Node.Reboot',
             waitOn: {
-                'refresh-catalog-megaraid': 'finished'
+                'refresh-catalog-lsall': 'finished'
             }
         }
 


### PR DESCRIPTION
After creating raid successfully, "driveid" catalog and "lsall" catalog needs to refresh.