### PR TITLE
add sas2ircu and sas3ircu support

### DIFF
--- a/data/templates/sasraid-config.sh
+++ b/data/templates/sasraid-config.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Copyright 2017, Dell EMC, Inc.
+
+hddArr=<%- JSON.stringify(hddArr) || [] %>
+ssdStoragePoolArr=<%- JSON.stringify(ssdStoragePoolArr) || [] %>
+ssdCacheCadeArr=<%- JSON.stringify(ssdCacheCadeArr) || [] %>
+path=<%=path%>
+controller=<%=controller%>
+
+echo hddArr is: $hddArr
+echo ssdStoragePoolArr is: $ssdStoragePoolArr
+echo ssdCacheCadeArr is: $ssdCacheCadeArr
+echo path is: $path
+echo controller is: $controller
+
+function create_vd_for_hdd()
+{
+    echo "Creating Virtual Disks For Hard Drives"
+    <% hddArr.forEach(function (value){ %>
+        convertedDrivesList=(<%=value.drives.replace(/[[\],]/g,' ')%>)
+        drives=""
+        for i in "${convertedDrivesList[@]}"
+            do
+                drives="${drives} <%=value.enclosure%>:$i"
+            done
+
+        echo running: $path $controller create <%=value.type%> MAX ${drives} <%=value.name%> noprompt
+        $path $controller create <%=value.type%> MAX ${drives} <%=value.name%> noprompt
+    <% }); %>
+    echo "Done Creating Virtual Disks For Hard Drives"
+}
+
+function delete()
+{
+    echo "Deleting $controller Virtual Disks"
+    echo running: $path $controller delete noprompt
+    $path $controller delete noprompt
+    echo "Done Deleting Virtual Disks"
+}
+
+delete
+create_vd_for_hdd

--- a/lib/graphs/bootstrap-megaraid-config-graph.js
+++ b/lib/graphs/bootstrap-megaraid-config-graph.js
@@ -15,6 +15,7 @@ module.exports = {
             ssdStoragePoolArr:null,
             ssdCacheCadeArr:null,
             path:null,
+            script:null,
             controller:null
         }
     },

--- a/lib/graphs/discovery-graph.js
+++ b/lib/graphs/discovery-graph.js
@@ -66,10 +66,26 @@ module.exports = {
             ignoreFailure: true
         },
         {
+            label: 'catalog-perccli',
+            taskName: 'Task.Catalog.perccli',
+            waitOn: {
+                'catalog-megaraid': 'finished'
+            },
+            ignoreFailure: true
+        },
+        {
+            label: 'catalog-sasraid',
+            taskName: 'Task.Catalog.sasraid',
+            waitOn: {
+                'catalog-perccli': 'finished'
+            },
+            ignoreFailure: true
+        },
+        {
             label: 'catalog-smart',
             taskName: 'Task.Catalog.smart',
             waitOn: {
-                'catalog-megaraid': 'finished'
+                'catalog-sasraid': 'finished'
             },
             ignoreFailure: true
         },

--- a/lib/graphs/rancher-discovery-graph.js
+++ b/lib/graphs/rancher-discovery-graph.js
@@ -74,10 +74,18 @@ module.exports = {
             ignoreFailure: true
         },
         {
+            label: 'catalog-sasraid',
+            taskName: 'Task.Catalog.sasraid',
+            waitOn: {
+                'catalog-perccli': 'finished'
+            },
+            ignoreFailure: true
+        },
+        {
             label: 'catalog-smart',
             taskName: 'Task.Catalog.smart',
             waitOn: {
-                'catalog-perccli': 'finished'
+                'catalog-sasraid': 'finished'
             },
             ignoreFailure: true
         },


### PR DESCRIPTION
My inspur server has a raid card (type sas2008) which can not support "perccli" and "storccli", and only support "sas2ircu".

so I add "catalog-sasraid" task using sudo python /opt/sas_info.py /opt/sas2ircu
I put "sas_info.py","sas2ircu","sas3ircu" in docker image ( secure.erase.docker.tar.xz) directory "/opt".

sas_info.py is a python script to parse "sas2ircu" and "sas3ircu" command output to json output.
sas2ircu is a raid command tool which support sas2008 raid card.
sas3ircu is a raid command tool which support sas3008 raid card.

I add a param "script" in payload .
script:"megaraid-config.sh" for megaraid
script:"sasraid-config.sh" for sasraid

also, during discovery  workflow, I add "catalog-sasraid" task.