### PR TITLE
[RAC-6743] fixed typo in esx-ks file

### DIFF
--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -30,7 +30,7 @@ rootpw <%-rootPlainPassword%>
     <% if(typeof n.ipv4 !== 'undefined') { %>
       <% ipopts = '--ip=' + n.ipv4.ipAddr + ' --gateway=' + n.ipv4.gateway + ' --netmask=' + n.ipv4.netmask %>
       <% if (typeof n.ipv4.vlanIds !== 'undefined' ) { %>
-        <% ipopts += ' --vlandid=' + n.ipv4.vlanIds[0] %>
+        <% ipopts += ' --vlanid=' + n.ipv4.vlanIds[0] %>
       <% } %>
       network --bootproto=static --device=<%=n.device%> <%=ipopts%>
     <% } else { %>


### PR DESCRIPTION
There is a typo which miss typed **_vlanid_** as **_vlandid_**, it will cause esxi installation failure when user try to setup vlan

@iceiilin @anhou @lanchongyizu @pengz1 