### PR TITLE
Error analyzing Windows unattend file when specifying two network devices

### DIFF
--- a/data/templates/unattend_server2012.xml
+++ b/data/templates/unattend_server2012.xml
@@ -149,6 +149,7 @@
         </component>
         <component name="Microsoft-Windows-TCPIP" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <% if( typeof networkDevices !== 'undefined' ) { %>
+            <Interfaces>
             <% networkDevices.forEach(function(n) { %>
             <% cidr_bits = 0 %>
             <% dhcp_ipv4 = false %>
@@ -198,7 +199,6 @@
             <% } %>
 
 
-            <Interfaces>
                 <Interface wcm:action="add">
                     <Identifier><%= n.device%></Identifier>
                     <Ipv4Settings>
@@ -240,8 +240,8 @@
                     </Routes>
                     <% } %>
                 </Interface>
-            </Interfaces>
             <% }); %>
+            </Interfaces>
             <% } %>
         </component>
 


### PR DESCRIPTION
Windows installer throws error about failure to handle unsttend.xml when specifying more than one network device.
Change the order in the template from
```
<component>
    <Interfaces>
        <Interface></Interface>
    </Interfaces>
    <Interfaces>
        <Interface></Interface>
    </Interfaces>
</component>
```
into 
```
<component>
    <Interfaces>
        <Interface></Interface>
        <Interface></Interface>
    </Interfaces>
</component>
```
The latter is the same with https://docs.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/microsoft-windows-tcpip-interfaces.