### PR TITLE
[RAC-6753]Correct several taskgraph's friendlyName

### DIFF
--- a/lib/graphs/bootstrap-ubuntu-graph.js
+++ b/lib/graphs/bootstrap-ubuntu-graph.js
@@ -3,7 +3,7 @@
 'use strict';
 
 module.exports = {
-    friendlyName: 'DEBUG Bootstrap Ubuntu ',
+    friendlyName: 'DEBUG Bootstrap Ubuntu',
     injectableName: 'Graph.BootstrapUbuntu',
     tasks: [
         {

--- a/lib/graphs/brocade-switch-discovery-graph.js
+++ b/lib/graphs/brocade-switch-discovery-graph.js
@@ -1,4 +1,5 @@
 // Copyright (C) 2016 Brocade Communications Systems, Inc.
+// Copyright © 2018 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 "use strict";
 

--- a/lib/graphs/brocade-switch-discovery-graph.js
+++ b/lib/graphs/brocade-switch-discovery-graph.js
@@ -3,7 +3,7 @@
 "use strict";
 
 module.exports = {
-    "friendlyName": "Brocade Switch  Discovery",
+    "friendlyName": "Brocade Switch Discovery",
     "injectableName": "Graph.Switch.Discovery.Brocade.Ztp",
     "tasks": [
         {

--- a/lib/graphs/discovery-mgmtsku-graph.js
+++ b/lib/graphs/discovery-mgmtsku-graph.js
@@ -3,7 +3,7 @@
 'use strict';
 
 module.exports = {
-    friendlyName: 'MgmtSKU. Discovery',
+    friendlyName: 'MgmtSKU Discovery',
     injectableName: 'Graph.MgmtSKU.Discovery',
     options: {
         defaults: {

--- a/lib/graphs/discovery-sku-orig-graph.js
+++ b/lib/graphs/discovery-sku-orig-graph.js
@@ -3,7 +3,7 @@
 'use strict';
 
 module.exports = {
-    friendlyName: 'SKU Discovery',
+    friendlyName: 'SKU Orig Discovery',
     injectableName: 'Graph.SKU.Orig.Discovery',
     options: {
         defaults: {

--- a/lib/graphs/flash-quanta-all-graph.js
+++ b/lib/graphs/flash-quanta-all-graph.js
@@ -3,7 +3,7 @@
 'use strict';
 
 module.exports = {
-    friendlyName: 'Flash Quanta BIOS',
+    friendlyName: 'Flash Quanta All Firmwares',
     injectableName: 'Graph.Flash.Quanta',
     options: {
         defaults: {

--- a/lib/graphs/pdu-discovery-graph.js
+++ b/lib/graphs/pdu-discovery-graph.js
@@ -3,7 +3,7 @@
 'use strict';
 
 module.exports = {
-    friendlyName: 'Switch Discovery',
+    friendlyName: 'PDU Discovery',
     injectableName: 'Graph.PDU.Discovery',
     options: {
         defaults: {

--- a/lib/graphs/rancher-discovery-graph.js
+++ b/lib/graphs/rancher-discovery-graph.js
@@ -3,7 +3,7 @@
 'use strict';
 
 module.exports = {
-    friendlyName: 'Discovery',
+    friendlyName: 'Discovery by Rancher',
     injectableName: 'Graph.rancherDiscovery',
     options: {
         'bootstrap-rancher': {


### PR DESCRIPTION
*Background*
It has been found during web ui development that some graphs have extra space in their friendlyname. After further screening, I also found some typo in some graph's friendlyname.  This is not a good style and we need to fix them all.

@lanchongyizu @pengz1 @yaolingling @iceiilin @mcgG @AlaricChan 
