### PR TITLE
Add update-lookups for redfish range discovery

### DIFF
--- a/lib/graphs/rancher-catalog-graph.js
+++ b/lib/graphs/rancher-catalog-graph.js
@@ -1,0 +1,126 @@
+// Copyright © 2018 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+'use strict';
+
+module.exports = {
+    friendlyName: 'Catalog by Rancher',
+    injectableName: 'Graph.Catalog.Rancher',
+    options: {
+        'bootstrap-rancher': {
+            'triggerGroup': 'catalog'
+        },
+        'finish-bootstrap-trigger': {
+            'triggerGroup': 'catalog'
+        }
+    },
+    tasks: [
+        {
+            label: 'set-boot-pxe',
+            taskName: 'Task.Obm.Node.PxeBoot',
+            ignoreFailure: true
+        },
+        {
+            label: 'reboot',
+            taskName: 'Task.Obm.Node.Reboot',
+            waitOn: {
+                'set-boot-pxe': 'finished'
+            }
+        },
+        {
+            label: 'bootstrap-rancher',
+            taskName: 'Task.Linux.Bootstrap.Rancher',
+            waitOn: {
+                'reboot': 'succeeded'
+            }
+        },
+        {
+            label: 'catalog-dmi',
+            taskName: 'Task.Catalog.dmi'
+        },
+        {
+            label: 'catalog-ohai',
+            taskName: 'Task.Catalog.ohai',
+            waitOn: {
+                'catalog-dmi': 'finished'
+            }
+        },
+        {
+            label: 'catalog-bmc',
+            taskName: 'Task.Catalog.bmc',
+            waitOn: {
+                'catalog-ohai': 'finished'
+            },
+            ignoreFailure: true
+        },
+        {
+            label: 'set-interfaces',
+            taskName: 'Task.Set.Interfaces',
+            waitOn: {
+                'catalog-bmc': 'finished'
+            },
+            ignoreFailure: true
+        },
+        {
+            label: 'catalog-lsall',
+            taskName: 'Task.Catalog.lsall',
+            waitOn: {
+                'set-interfaces': 'finished'
+            },
+            ignoreFailure: true
+        },
+        {
+            label: 'catalog-megaraid',
+            taskName: 'Task.Catalog.megaraid',
+            waitOn: {
+                'catalog-lsall': 'finished'
+            },
+            ignoreFailure: true
+        },
+        {
+            label: 'catalog-perccli',
+            taskName: 'Task.Catalog.perccli',
+            waitOn: {
+                'catalog-megaraid': 'finished'
+            },
+            ignoreFailure: true
+        },
+        {
+            label: 'catalog-smart',
+            taskName: 'Task.Catalog.smart',
+            waitOn: {
+                'catalog-perccli': 'finished'
+            },
+            ignoreFailure: true
+        },
+        {
+            label: 'catalog-driveid',
+            taskName: 'Task.Catalog.Drive.Id',
+            waitOn: {
+                'catalog-smart': 'finished'
+            },
+            ignoreFailure: true
+        },
+        {
+            label: 'catalog-lldp',
+            taskName: 'Task.Catalog.LLDP',
+            waitOn: {
+                'catalog-driveid': 'finished'
+            },
+            ignoreFailure: true
+        },
+        {
+            label: 'shell-reboot',
+            taskName: 'Task.ProcShellReboot',
+            waitOn: {
+                'catalog-lldp': 'finished'
+            }
+        },
+        {
+            label: 'finish-bootstrap-trigger',
+            taskName: 'Task.Trigger.Send.Finish',
+            waitOn: {
+                'catalog-lldp': 'finished'
+            }
+        }
+    ]
+};

--- a/lib/graphs/redfish-discovery-ip-range-graph.js
+++ b/lib/graphs/redfish-discovery-ip-range-graph.js
@@ -36,6 +36,13 @@ module.exports = {
             waitOn: {
                 'redfish-discovery-list': 'succeeded'
             }
+        },
+        {
+            label: 'redfish-update-lookups',
+            taskName: 'Task.Redfish.Update.Lookups',
+            waitOn: {
+                'redfish-catalog-discovered': 'succeeded'
+            }
         }
     ]
 };

--- a/lib/services/profile-api-service.js
+++ b/lib/services/profile-api-service.js
@@ -334,7 +334,7 @@ function profileApiServiceFactory(
                         })
                         .spread(function (profile, properties) {
                             var _options;
-                            if (node.type === 'compute') {
+                            if (node.type === 'compute' || node.type === 'redfish') {
                                 _options = self.convertProperties(properties);
                             } else if (node.type === 'switch') {
                                 var switchVendor;

--- a/spec/lib/graphs/rancher-catalog-graph-spec.js
+++ b/spec/lib/graphs/rancher-catalog-graph-spec.js
@@ -1,0 +1,15 @@
+// Copyright © 2018 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+'use strict';
+
+describe(require('path').basename(__filename), function () {
+    var base = require('./base-graph-spec');
+
+    base.before(function (context) {
+        context.taskdefinition = helper.require('/lib/graphs/rancher-catalog-graph.js');
+    });
+
+    describe('graph', function () {
+        base.examples();
+    });
+});


### PR DESCRIPTION
Here is the scenario we are trying to accomplish (The user already has
the nodes powered on)
1. knowing the Idrac IP, we want to run the redfish discovery workflow.
This step will create the obm and catalog redfish. We can add a step
here to get the host mac addresses and populate the lookup table.
2. Since the node is discovered a pxe discovery shouldn't trigger
automatically but we should have a pxe discovery workflow that the user
can run against a discovered node to populate the catalog with pxe
cataloging data.
https://rackhd.atlassian.net/browse/RAC-6777

depends on: https://github.com/RackHD/on-tasks/pull/596

@keedya @iceiilin @pengz1 